### PR TITLE
Implement DOM sync helper with UI container

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 <body>
     <div id="app">
         <div id="game-container"></div>
+        <div id="ui-container"></div>
     </div>
     <script type="module" src="src/main.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -13,3 +13,28 @@ body {
     justify-content: center;
     align-items: center;
 }
+
+#ui-container {
+    /* 화면 전체를 덮도록 설정하고, 캔버스 위에 위치시킵니다. */
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* 이 컨테이너 자체는 클릭되지 않도록 하여, 아래 캔버스로 클릭 이벤트가 전달되게 합니다. */
+    pointer-events: none;
+    overflow: hidden; /* 화면 밖으로 나가는 UI는 숨깁니다. */
+}
+
+/* UI 요소들의 기본 스타일입니다. */
+.ui-element {
+    /* 개별 UI 요소는 다시 클릭 가능하도록 설정합니다. */
+    pointer-events: all;
+    padding: 8px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid #fff;
+    border-radius: 5px;
+    color: #fff;
+    /* 사용자가 텍스트를 선택할 수 없도록 하여 더블클릭 시 불편함을 줄입니다. */
+    user-select: none;
+}

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,28 +1,81 @@
 import { Scene } from 'phaser';
+import { DomSync } from '../utils/DomSync.js';
 
 export class Game extends Scene
 {
     constructor ()
     {
         super('Game');
+        // 여러 DomSync 인스턴스를 관리할 배열
+        this.domSyncs = [];
     }
 
     create ()
     {
-        this.cameras.main.setBackgroundColor(0x00ff00);
+        this.cameras.main.setBackgroundColor(0x0a440a);
 
-        this.add.image(512, 384, 'background').setAlpha(0.5);
+        // 카메라 이동을 확인하기 위한 배경 이미지
+        this.add.image(512, 384, 'background').setScale(2).setAlpha(0.7);
 
-        this.add.text(512, 384, 'Make something fun!\nand share it with us:\nsupport@phaser.io', {
-            fontFamily: 'Arial Black', fontSize: 38, color: '#ffffff',
-            stroke: '#000000', strokeThickness: 8,
-            align: 'center'
-        }).setOrigin(0.5);
+        // --- 1. Phaser 게임 오브젝트 생성 ---
+        // 월드 좌표 (512, 384)에 전사 스프라이트를 추가합니다.
+        const warrior = this.add.sprite(512, 384, 'warrior');
 
-        this.input.once('pointerdown', () => {
+        // --- 2. 동기화할 DOM 요소 생성 ---
+        const uiContainer = document.getElementById('ui-container');
+        const warriorLabel = document.createElement('div');
+        warriorLabel.className = 'ui-element';
+        warriorLabel.innerHTML = '<strong>용맹한 전사</strong><br><span>HP: 100/100</span>';
+        uiContainer.appendChild(warriorLabel);
 
-            this.scene.start('GameOver');
-
+        // --- 3. DomSync로 두 요소 연결 ---
+        // 전사 스프라이트와 이름표 DOM 요소를 연결하는 인스턴스를 생성합니다.
+        const warriorDomSync = new DomSync(this, warrior, warriorLabel);
+        this.domSyncs.push(warriorDomSync);
+        
+        // DOM 요소에 직접 이벤트 리스너를 추가할 수 있습니다.
+        warriorLabel.addEventListener('click', () => {
+            console.log('DOM 이름표를 클릭했습니다!');
+            // 스프라이트에 시각적 효과를 줍니다.
+            warrior.setTint(0xff0000);
+            this.time.delayedCall(200, () => warrior.clearTint());
         });
+
+        // --- 카메라 제어 (데모용) ---
+        this.cameras.main.setZoom(1);
+        this.cameras.main.centerOn(512, 384);
+
+        // 마우스 휠로 줌 인/아웃
+        this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY, deltaZ) => {
+            const newZoom = this.cameras.main.zoom - deltaY * 0.001;
+            this.cameras.main.setZoom(Math.max(0.5, Math.min(3, newZoom))); // 최소/최대 줌 레벨 설정
+        });
+
+        // 마우스 드래그로 카메라 이동 (패닝)
+        this.input.on('pointermove', (pointer) => {
+            if (!pointer.isDown) return;
+            this.cameras.main.scrollX -= (pointer.x - pointer.prevPosition.x) / this.cameras.main.zoom;
+            this.cameras.main.scrollY -= (pointer.y - pointer.prevPosition.y) / this.cameras.main.zoom;
+        });
+
+        // 안내 텍스트
+        this.add.text(512, 100, '마우스 휠로 줌, 드래그로 맵 이동', {
+            fontFamily: 'Arial', fontSize: 24, color: '#ffffff',
+            stroke: '#000000', strokeThickness: 4,
+        }).setOrigin(0.5).setScrollFactor(0); // ScrollFactor(0)으로 설정하면 카메라가 움직여도 제자리에 고정됩니다.
+    }
+
+    update()
+    {
+        // 매 프레임마다 모든 DomSync 인스턴스를 업데이트하여 위치를 동기화합니다.
+        for (let i = this.domSyncs.length - 1; i >= 0; i--) {
+            const sync = this.domSyncs[i];
+            if (sync.domElement) {
+                sync.update();
+            } else {
+                // domElement가 제거되었으면 배열에서도 제거합니다.
+                this.domSyncs.splice(i, 1);
+            }
+        }
     }
 }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -33,6 +33,7 @@ export class Preloader extends Scene
         this.load.setPath('assets');
 
         this.load.image('logo', 'logo.png');
+        this.load.image('warrior', 'images/unit/warrior.png');
     }
 
     create ()

--- a/src/game/utils/DomSync.js
+++ b/src/game/utils/DomSync.js
@@ -1,0 +1,61 @@
+/**
+ * Phaser 게임 오브젝트와 DOM 요소의 위치 및 크기를 동기화하는 헬퍼 클래스
+ */
+export class DomSync {
+    /**
+     * @param {Phaser.Scene} scene 게임 오브젝트가 속한 씬
+     * @param {Phaser.GameObjects.GameObject} gameObject 동기화할 Phaser 게임 오브젝트
+     * @param {HTMLElement} domElement 동기화할 HTML DOM 요소
+     */
+    constructor(scene, gameObject, domElement) {
+        this.scene = scene;
+        this.gameObject = gameObject;
+        this.domElement = domElement;
+        this.camera = scene.cameras.main;
+
+        // DOM 요소의 스타일을 초기 설정합니다.
+        // CSS transform을 사용하기 위해 position을 absolute로 설정합니다.
+        this.domElement.style.position = 'absolute';
+        this.domElement.style.willChange = 'transform'; // 브라우저에 렌더링 최적화를 알려줍니다.
+        this.domElement.style.transformOrigin = 'top left'; // 줌인/아웃 시 왼쪽 상단을 기준으로 크기가 조절되도록 합니다.
+    }
+
+    /**
+     * 이 메소드는 씬의 update 루프 안에서 계속 호출되어야 합니다.
+     */
+    update() {
+        if (!this.gameObject.scene) {
+            // 게임오브젝트가 파괴된 경우, DOM 요소도 제거합니다.
+            this.destroy();
+            return;
+        }
+        
+        const { x, y } = this.gameObject;
+        const { zoom, scrollX, scrollY } = this.camera;
+
+        // 페이지 내에서 캔버스의 절대 위치를 가져옵니다.
+        const gameBounds = this.scene.sys.game.canvas.getBoundingClientRect();
+
+        // 카메라의 스크롤과 줌을 고려하여 게임 오브젝트의 화면상 위치를 계산합니다.
+        const screenX = (x - scrollX) * zoom;
+        const screenY = (y - scrollY) * zoom;
+
+        // DOM 요소가 위치할 최종 좌표입니다.
+        const domX = gameBounds.left + screenX;
+        const domY = gameBounds.top + screenY;
+
+        // transform 속성을 사용하여 DOM 요소의 위치와 크기를 한 번에 적용합니다.
+        // top/left를 직접 바꾸는 것보다 성능상 이점이 있습니다.
+        this.domElement.style.transform = `translate(${domX}px, ${domY}px) scale(${zoom})`;
+    }
+
+    /**
+     * DOM 요소를 제거하고 참조를 정리합니다.
+     */
+    destroy() {
+        if (this.domElement) {
+            this.domElement.remove();
+        }
+        this.domElement = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add `DomSync` utility to sync Phaser objects with DOM nodes
- load warrior sprite in `Preloader`
- introduce `ui-container` for DOM-based UI elements
- style `.ui-element` elements
- show an example DOM-synced label in `Game`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20` *(404 as file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687b9be45810832790a9ecee7ee3beb9