### PR TITLE
Fix base path for production build

### DIFF
--- a/vite/config.prod.mjs
+++ b/vite/config.prod.mjs
@@ -17,7 +17,9 @@ const phasermsg = () => {
 }   
 
 export default defineConfig({
-    base: './',
+    // Set the base path so assets resolve correctly when served from the
+    // repository root on GitHub Pages or similar static hosts.
+    base: '/H-M-B/',
     logLevel: 'warn',
     build: {
         rollupOptions: {


### PR DESCRIPTION
## Summary
- set the Vite production config `base` path to `/H-M-B/`
- document the reason with a short comment

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b9f3c0e008327aa9a1f66f5cdca0f