### PR TITLE
Fix asset and module paths for browser loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
     <title>Phaser - Template</title>
 </head>
 

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -1,8 +1,8 @@
-import { Boot } from './scenes/Boot';
-import { Game as MainGame } from './scenes/Game';
-import { GameOver } from './scenes/GameOver';
-import { MainMenu } from './scenes/MainMenu';
-import { Preloader } from './scenes/Preloader';
+import { Boot } from './scenes/Boot.js';
+import { Game as MainGame } from './scenes/Game.js';
+import { GameOver } from './scenes/GameOver.js';
+import { MainMenu } from './scenes/MainMenu.js';
+import { Preloader } from './scenes/Preloader.js';
 import { AUTO, Game } from 'phaser';
 
 //  Find out more information about the Game Config at:

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import StartGame from './game/main';
+import StartGame from './game/main.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 


### PR DESCRIPTION
## Summary
- fix stylesheet link to be relative
- add `.js` extensions to ES module imports

## Testing
- `python3 -m http.server 8000 &` (server startup)
- `curl http://localhost:8000/index.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687ba2a64f208327ab010b6d7e8ac3b4