### PR TITLE
Fix local dev imports for Phaser

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -3,7 +3,9 @@ import { Game as MainGame } from './scenes/Game.js';
 import { GameOver } from './scenes/GameOver.js';
 import { MainMenu } from './scenes/MainMenu.js';
 import { Preloader } from './scenes/Preloader.js';
-import { AUTO, Game } from 'phaser';
+// phaser 모듈을 직접 불러오면 로컬 서버에서 해석되지 않으므로
+// node_modules 경로를 상대 경로로 지정합니다.
+import { AUTO, Game } from '../../node_modules/phaser/dist/phaser.esm.js';
 
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Vite 없이 실행할 수 있도록 phaser ESM을 직접 참조합니다.
+import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
 
 export class Boot extends Scene
 {

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,4 +1,4 @@
-import { Scene } from 'phaser';
+import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
 import { DomSync } from '../utils/DomSync.js';
 
 export class Game extends Scene

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,4 +1,4 @@
-import { Scene } from 'phaser';
+import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
 
 export class GameOver extends Scene
 {

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,4 +1,4 @@
-import { Scene } from 'phaser';
+import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
 
 export class MainMenu extends Scene
 {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,4 @@
-import { Scene } from 'phaser';
+import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
 
 export class Preloader extends Scene
 {


### PR DESCRIPTION
## Summary
- reference Phaser through relative paths for local ESM loading

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687ba5b309748327a31778a2ec52e608