### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="public/style.css">
     <title>Phaser - Template</title>
 </head>
 

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -5,7 +5,8 @@ import { MainMenu } from './scenes/MainMenu.js';
 import { Preloader } from './scenes/Preloader.js';
 // phaser 모듈을 직접 불러오면 로컬 서버에서 해석되지 않으므로
 // node_modules 경로를 상대 경로로 지정합니다.
-import { AUTO, Game } from '../../node_modules/phaser/dist/phaser.esm.js';
+// Phaser를 CDN에서 불러와 배포 시 404 오류를 방지합니다.
+import { AUTO, Game } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -1,5 +1,6 @@
 // Vite 없이 실행할 수 있도록 phaser ESM을 직접 참조합니다.
-import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
+// Phaser 모듈을 CDN에서 가져옵니다.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class Boot extends Scene
 {

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,4 +1,4 @@
-import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { DomSync } from '../utils/DomSync.js';
 
 export class Game extends Scene

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,4 +1,4 @@
-import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class GameOver extends Scene
 {

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,4 +1,4 @@
-import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class MainMenu extends Scene
 {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,4 @@
-import { Scene } from '../../../node_modules/phaser/dist/phaser.esm.js';
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 export class Preloader extends Scene
 {


### PR DESCRIPTION
## Summary
- load `style.css` from the `public` folder
- fetch Phaser from a CDN instead of a local `node_modules` path

## Testing
- `npm run build`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687ba7d61df48327a20255be6434567c