### PR TITLE
Fix Phaser reference in game bootstrap

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -6,12 +6,12 @@ import { Preloader } from './scenes/Preloader.js';
 // phaser 모듈을 직접 불러오면 로컬 서버에서 해석되지 않으므로
 // node_modules 경로를 상대 경로로 지정합니다.
 // Phaser를 CDN에서 불러와 배포 시 404 오류를 방지합니다.
-import { AUTO, Game } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig
 const config = {
-    type: AUTO,
+    type: Phaser.AUTO,
     width: 1024,
     height: 768,
     parent: 'game-container',
@@ -33,7 +33,7 @@ const config = {
 
 const StartGame = (parent) => {
 
-    return new Game({ ...config, parent });
+    return new Phaser.Game({ ...config, parent });
 
 }
 


### PR DESCRIPTION
## Summary
- import Phaser as a module in game bootstrap
- use Phaser constants for config and game initialization

## Testing
- `curl http://localhost:8000/debug.html | head -n 20`
- `npm run build-nolog`


------
https://chatgpt.com/codex/tasks/task_e_687baad8cbb48327a905755596968d61