### PR TITLE
Fix Phaser import for CDN ESM

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -6,7 +6,8 @@ import { Preloader } from './scenes/Preloader.js';
 // phaser 모듈을 직접 불러오면 로컬 서버에서 해석되지 않으므로
 // node_modules 경로를 상대 경로로 지정합니다.
 // Phaser를 CDN에서 불러와 배포 시 404 오류를 방지합니다.
-import Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+// ESM 빌드에는 기본 내보내기가 없으므로 전체 네임스페이스를 가져옵니다.
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig


### PR DESCRIPTION
## Summary
- import Phaser as namespace when loading from CDN

## Testing
- `python3 -m http.server 8000 & curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687baf99018083278eea1733576dbb71