### PR TITLE
Add debug logging engine with combat manager

### DIFF
--- a/src/game/debug/CombatLogManager.js
+++ b/src/game/debug/CombatLogManager.js
@@ -1,0 +1,31 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class CombatLogManager {
+    constructor() {
+        this.name = 'Combat';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 공격의 상세 계산식을 콘솔에 그룹화하여 출력합니다.
+     * @param {object} attacker - 공격자 정보
+     * @param {object} defender - 방어자 정보
+     * @param {number} baseDamage - 기본 데미지
+     * @param {number} finalDamage - 최종 데미지
+     */
+    logAttackCalculation(attacker, defender, baseDamage, finalDamage) {
+        console.groupCollapsed(`[${this.name}] ${attacker.name}이(가) ${defender.name}을(를) 공격!`);
+
+        debugLogEngine.log(this.name, '--- 공격 상세 계산 ---');
+        debugLogEngine.log(this.name, `공격자: ${attacker.name} (공격력: ${attacker.atk})`);
+        debugLogEngine.log(this.name, `방어자: ${defender.name} (방어력: ${defender.def})`);
+        debugLogEngine.log(this.name, `기본 데미지: ${baseDamage}`);
+        debugLogEngine.log(this.name, '데미지 공식: 기본 데미지 - 방어자 방어력');
+        debugLogEngine.log(this.name, `계산: ${baseDamage} - ${defender.def} = ${finalDamage}`);
+        debugLogEngine.log(this.name, `최종 적용 데미지: ${finalDamage}`);
+
+        console.groupEnd();
+    }
+}
+
+export const combatLogManager = new CombatLogManager();

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,5 +1,7 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { DomSync } from '../utils/DomSync.js';
+// 전투 로그 매니저를 가져옵니다.
+import { combatLogManager } from '../debug/CombatLogManager.js';
 
 export class Game extends Scene
 {
@@ -63,6 +65,17 @@ export class Game extends Scene
             fontFamily: 'Arial', fontSize: 24, color: '#ffffff',
             stroke: '#000000', strokeThickness: 4,
         }).setOrigin(0.5).setScrollFactor(0); // ScrollFactor(0)으로 설정하면 카메라가 움직여도 제자리에 고정됩니다.
+
+        // --- 디버그 로그 테스트 ---
+        const warriorStats = { name: '용맹한 전사', atk: 25, def: 10 };
+        const zombieStats = { name: '비틀거리는 좀비', atk: 15, def: 5 };
+
+        combatLogManager.logAttackCalculation(warriorStats, zombieStats, 25, 20);
+        combatLogManager.logAttackCalculation(zombieStats, warriorStats, 15, 5);
+
+        this.input.once('pointerdown', () => {
+            this.scene.start('GameOver');
+        });
     }
 
     update()

--- a/src/game/utils/DebugLogEngine.js
+++ b/src/game/utils/DebugLogEngine.js
@@ -1,0 +1,98 @@
+/**
+ * 브라우저 개발자 도구 콘솔에 구조화된 로그를 출력하는 엔진 (싱글턴)
+ */
+class DebugLogEngine {
+    constructor() {
+        if (DebugLogEngine.instance) {
+            return DebugLogEngine.instance;
+        }
+        
+        // 이 값을 false로 바꾸면 모든 디버그 로그가 출력되지 않습니다.
+        this.enabled = true;
+        
+        this.managers = {};
+        this._welcomeMessage();
+
+        DebugLogEngine.instance = this;
+    }
+
+    /**
+     * 엔진이 처음 초기화될 때 콘솔에 환영 메시지를 출력합니다.
+     */
+    _welcomeMessage() {
+        if (!this.enabled) return;
+        console.log(
+            '%c[DebugLogEngine]%c가 활성화되었습니다. 이제 매니저를 등록할 수 있습니다.',
+            'color: #7F00FF; font-weight: bold;', // 보라색, 굵게
+            'color: default;'
+        );
+    }
+
+    /**
+     * 새로운 디버그 매니저를 엔진에 등록합니다.
+     * @param {object} manager - 등록할 매니저. 'name' 속성이 필수입니다.
+     */
+    register(manager) {
+        if (manager && manager.name) {
+            this.managers[manager.name] = manager;
+        } else {
+            this.error('Engine', '매니저 등록 실패: 매니저는 반드시 name 속성을 가져야 합니다.');
+        }
+    }
+
+    /**
+     * 일반 로그를 출력합니다.
+     * @param {string} source - 로그 출처 (매니저 이름)
+     * @param  {...any} args - 출력할 내용들
+     */
+    log(source, ...args) {
+        if (!this.enabled) return;
+        // 출처(source)에 따라 색상이 바뀌도록 스타일을 적용합니다.
+        console.log(
+            `%c[${source}]`,
+            `color: ${this._getSourceColor(source)}; font-weight: bold;`,
+            ...args
+        );
+    }
+
+    /**
+     * 경고 로그를 출력합니다.
+     * @param {string} source - 로그 출처
+     * @param  {...any} args - 출력할 내용들
+     */
+    warn(source, ...args) {
+        if (!this.enabled) return;
+        console.warn(`[${source}]`, ...args);
+    }
+
+    /**
+     * 에러 로그를 출력합니다.
+     * @param {string} source - 로그 출처
+     * @param  {...any} args - 출력할 내용들
+     */
+    error(source, ...args) {
+        if (!this.enabled) return;
+        console.error(`[${source}]`, ...args);
+    }
+
+    /**
+     * 로그 출처(source) 문자열을 기반으로 고유한 색상을 생성합니다.
+     * @param {string} source - 출처 문자열
+     * @returns {string} - CSS 색상 코드
+     */
+    _getSourceColor(source) {
+        let hash = 0;
+        for (let i = 0; i < source.length; i++) {
+            hash = source.charCodeAt(i) + ((hash << 5) - hash);
+        }
+        let color = '#';
+        for (let i = 0; i < 3; i++) {
+            const value = (hash >> (i * 8)) & 0xFF;
+            color += ('00' + value.toString(16)).substr(-2);
+        }
+        return color;
+    }
+}
+
+// 다른 파일에서 쉽게 사용할 수 있도록 유일한 인스턴스를 생성하여 내보냅니다.
+export const debugLogEngine = new DebugLogEngine();


### PR DESCRIPTION
## Summary
- add `DebugLogEngine` singleton for colorful structured logs
- introduce `CombatLogManager` for attack calculation logs
- demonstrate debug logs in `Game` scene

## Testing
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bb77d6e148327863ce75cdab5c9eb