### PR TITLE
Add CameraEngine and camera demo

### DIFF
--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,94 +1,55 @@
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-import { DomSync } from '../utils/DomSync.js';
-// 전투 로그 매니저를 가져옵니다.
-import { combatLogManager } from '../debug/CombatLogManager.js';
+import { Scene } from "https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js";
+import { cameraEngine } from '../utils/CameraEngine.js';
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
 
-export class Game extends Scene
-{
-    constructor ()
-    {
+export class Game extends Scene {
+    constructor() {
         super('Game');
-        // 여러 DomSync 인스턴스를 관리할 배열
-        this.domSyncs = [];
     }
 
-    create ()
-    {
+    create() {
         this.cameras.main.setBackgroundColor(0x0a440a);
+        this.add.image(512, 384, 'background').setAlpha(0.5);
 
-        // 카메라 이동을 확인하기 위한 배경 이미지
-        this.add.image(512, 384, 'background').setScale(2).setAlpha(0.7);
+        // --- 1. 카메라 엔진에 현재 씬 등록 ---
+        // 이 과정이 있어야 엔진이 어떤 카메라를 제어할지 알 수 있습니다.
+        cameraEngine.registerScene(this);
 
-        // --- 1. Phaser 게임 오브젝트 생성 ---
-        // 월드 좌표 (512, 384)에 전사 스프라이트를 추가합니다.
-        const warrior = this.add.sprite(512, 384, 'warrior');
+        // --- 2. 테스트용 유닛(스프라이트) 생성 ---
+        const warrior = this.add.sprite(250, 384, 'warrior').setInteractive();
+        warrior.name = '전사'; // 디버그 로그에 표시될 이름
 
-        // --- 2. 동기화할 DOM 요소 생성 ---
-        const uiContainer = document.getElementById('ui-container');
-        const warriorLabel = document.createElement('div');
-        warriorLabel.className = 'ui-element';
-        warriorLabel.innerHTML = '<strong>용맹한 전사</strong><br><span>HP: 100/100</span>';
-        uiContainer.appendChild(warriorLabel);
-
-        // --- 3. DomSync로 두 요소 연결 ---
-        // 전사 스프라이트와 이름표 DOM 요소를 연결하는 인스턴스를 생성합니다.
-        const warriorDomSync = new DomSync(this, warrior, warriorLabel);
-        this.domSyncs.push(warriorDomSync);
-        
-        // DOM 요소에 직접 이벤트 리스너를 추가할 수 있습니다.
-        warriorLabel.addEventListener('click', () => {
-            console.log('DOM 이름표를 클릭했습니다!');
-            // 스프라이트에 시각적 효과를 줍니다.
-            warrior.setTint(0xff0000);
-            this.time.delayedCall(200, () => warrior.clearTint());
-        });
-
-        // --- 카메라 제어 (데모용) ---
-        this.cameras.main.setZoom(1);
-        this.cameras.main.centerOn(512, 384);
-
-        // 마우스 휠로 줌 인/아웃
-        this.input.on('wheel', (pointer, gameObjects, deltaX, deltaY, deltaZ) => {
-            const newZoom = this.cameras.main.zoom - deltaY * 0.001;
-            this.cameras.main.setZoom(Math.max(0.5, Math.min(3, newZoom))); // 최소/최대 줌 레벨 설정
-        });
-
-        // 마우스 드래그로 카메라 이동 (패닝)
-        this.input.on('pointermove', (pointer) => {
-            if (!pointer.isDown) return;
-            this.cameras.main.scrollX -= (pointer.x - pointer.prevPosition.x) / this.cameras.main.zoom;
-            this.cameras.main.scrollY -= (pointer.y - pointer.prevPosition.y) / this.cameras.main.zoom;
-        });
-
-        // 안내 텍스트
-        this.add.text(512, 100, '마우스 휠로 줌, 드래그로 맵 이동', {
-            fontFamily: 'Arial', fontSize: 24, color: '#ffffff',
-            stroke: '#000000', strokeThickness: 4,
-        }).setOrigin(0.5).setScrollFactor(0); // ScrollFactor(0)으로 설정하면 카메라가 움직여도 제자리에 고정됩니다.
-
-        // --- 디버그 로그 테스트 ---
-        const warriorStats = { name: '용맹한 전사', atk: 25, def: 10 };
-        const zombieStats = { name: '비틀거리는 좀비', atk: 15, def: 5 };
-
-        combatLogManager.logAttackCalculation(warriorStats, zombieStats, 25, 20);
-        combatLogManager.logAttackCalculation(zombieStats, warriorStats, 15, 5);
-
-        this.input.once('pointerdown', () => {
-            this.scene.start('GameOver');
-        });
-    }
-
-    update()
-    {
-        // 매 프레임마다 모든 DomSync 인스턴스를 업데이트하여 위치를 동기화합니다.
-        for (let i = this.domSyncs.length - 1; i >= 0; i--) {
-            const sync = this.domSyncs[i];
-            if (sync.domElement) {
-                sync.update();
-            } else {
-                // domElement가 제거되었으면 배열에서도 제거합니다.
-                this.domSyncs.splice(i, 1);
-            }
+        const zombie = this.add.sprite(774, 384, 'zombie'); // 아직 로드하지 않았으니 이미지가 깨질 수 있습니다.
+        zombie.name = '좀비';
+        // warrior 이미지를 임시로 사용합니다. Preloader.js에 'zombie'를 추가하면 정상적으로 보입니다.
+        if (!this.textures.exists('zombie')) {
+            zombie.setTexture('warrior').setTint(0x88ff88);
         }
+
+        // --- 3. 카메라 연출 실행 및 이벤트 연결 ---
+        this.add.text(512, 50, '전사를 클릭하면 전투 연출이 시작됩니다.', {
+            fontFamily: 'Arial Black', fontSize: 24, color: '#ffffff',
+            stroke: '#000000', strokeThickness: 6
+        }).setOrigin(0.5);
+
+        warrior.on('pointerdown', async () => {
+            debugLogEngine.log('Game', '전투 시퀀스 시작!');
+            
+            // async/await를 사용하여 카메라 연출을 순서대로 실행합니다.
+            // 1. 전사 클로즈업
+            await cameraEngine.closeupOn(warrior, 1.5, 500);
+            
+            // 2. 공격하는 것처럼 화면 흔들기
+            await cameraEngine.shake(0.02, 300);
+            
+            // 3. 좀비에게 피격 이펙트 (간단히 색상 변경으로 표현)
+            zombie.setTint(0xff0000);
+            this.time.delayedCall(100, () => zombie.clearTint().setTint(0x88ff88));
+            
+            // 4. 원래 시점으로 복귀
+            await cameraEngine.reset(500);
+
+            debugLogEngine.log('Game', '전투 시퀀스 종료!');
+        });
     }
 }

--- a/src/game/utils/CameraEngine.js
+++ b/src/game/utils/CameraEngine.js
@@ -1,0 +1,98 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 게임 카메라의 복잡한 움직임과 연출을 담당하는 엔진 (싱글턴)
+ */
+class CameraEngine {
+    constructor() {
+        if (CameraEngine.instance) {
+            return CameraEngine.instance;
+        }
+        this.scene = null;
+        this.camera = null;
+
+        debugLogEngine.log('CameraEngine', '카메라 엔진 초기화. 씬이 등록되기를 기다립니다...');
+        CameraEngine.instance = this;
+    }
+    
+    /**
+     * 엔진이 제어할 씬과 카메라를 등록합니다.
+     * 보통 새로운 씬이 시작될 때마다 호출됩니다.
+     * @param {Phaser.Scene} scene - 제어할 대상 씬
+     */
+    registerScene(scene) {
+        this.scene = scene;
+        this.camera = scene.cameras.main;
+        debugLogEngine.log('CameraEngine', `[${scene.scene.key}] 씬의 카메라를 등록했습니다.`);
+    }
+
+    /**
+     * 특정 게임 오브젝트에 줌인하여 클로즈업합니다.
+     * @param {Phaser.GameObjects.GameObject} target - 클로즈업할 대상
+     * @param {number} zoomLevel - 줌 레벨 (예: 2는 2배 확대)
+     * @param {number} duration - 효과에 걸리는 시간 (밀리초)
+     * @returns {Promise<void>} 카메라 효과가 완료되면 resolve되는 Promise
+     */
+    closeupOn(target, zoomLevel = 2, duration = 1000) {
+        return new Promise(resolve => {
+            if (!this.camera) {
+                debugLogEngine.error('CameraEngine', '카메라가 등록되지 않았습니다.');
+                return resolve();
+            }
+
+            debugLogEngine.log('CameraEngine', `${target.name || '대상'}에 클로즈업합니다.`);
+            
+            // Pan(이동)과 Zoom(확대) 효과를 동시에 실행합니다.
+            this.camera.pan(target.x, target.y, duration, 'Sine.easeInOut');
+            this.camera.zoomTo(zoomLevel, duration, 'Sine.easeInOut');
+
+            // 효과가 완료되면 Promise를 resolve하여 다음 동작을 수행할 수 있도록 합니다.
+            this.scene.time.delayedCall(duration, resolve);
+        });
+    }
+
+    /**
+     * 카메라를 원래의 줌과 위치로 부드럽게 복원합니다.
+     * @param {number} duration - 효과에 걸리는 시간 (밀리초)
+     * @returns {Promise<void>} 카메라 효과가 완료되면 resolve되는 Promise
+     */
+    reset(duration = 1000) {
+        return new Promise(resolve => {
+            if (!this.camera) {
+                debugLogEngine.error('CameraEngine', '카메라가 등록되지 않았습니다.');
+                return resolve();
+            }
+            
+            debugLogEngine.log('CameraEngine', '카메라를 원래 상태로 복원합니다.');
+            
+            // 기본 줌 레벨(1)과 월드 중앙으로 되돌아갑니다.
+            // Pan과 Zoom의 대상 좌표와 레벨은 게임에 맞게 수정할 수 있습니다.
+            this.camera.pan(512, 384, duration, 'Sine.easeInOut');
+            this.camera.zoomTo(1, duration, 'Sine.easeInOut');
+
+            this.scene.time.delayedCall(duration, resolve);
+        });
+    }
+
+    /**
+     * 화면을 흔들어 타격감 등을 연출합니다.
+     * @param {number} intensity - 흔들림의 강도 (0에서 1 사이)
+     * @param {number} duration - 효과에 걸리는 시간 (밀리초)
+     * @returns {Promise<void>} 카메라 효과가 완료되면 resolve되는 Promise
+     */
+    shake(intensity = 0.01, duration = 200) {
+        return new Promise(resolve => {
+            if (!this.camera) {
+                debugLogEngine.error('CameraEngine', '카메라가 등록되지 않았습니다.');
+                return resolve();
+            }
+
+            this.camera.shake(duration, intensity);
+            
+            this.scene.time.delayedCall(duration, resolve);
+        });
+    }
+}
+
+// 다른 파일에서 쉽게 사용하도록 유일한 인스턴스를 생성하여 내보냅니다.
+export const cameraEngine = new CameraEngine();


### PR DESCRIPTION
## Summary
- implement a new `CameraEngine` utility to manage complex camera moves
- update `Game` scene to demonstrate camera effects

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bba7419548327a37bf769d538b55b