### PR TITLE
Add debug log managers for combat and camera

### DIFF
--- a/src/game/debug/DebugCameraLogManager.js
+++ b/src/game/debug/DebugCameraLogManager.js
@@ -1,0 +1,42 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugCameraLogManager {
+    constructor() {
+        // 이 매니저의 이름을 'DebugCamera'로 정합니다.
+        this.name = 'DebugCamera';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 게임 시작 시 해상도 및 카메라 관련 정보를 로그로 남깁니다.
+     * @param {Phaser.Cameras.Scene2D.Camera} camera - Phaser 카메라 객체
+     * @param {Phaser.Core.Config} config - 게임 설정 객체
+     */
+    logInitialState(camera, config) {
+        console.groupCollapsed(`%c[${this.name}]`, `color: #3b82f6; font-weight: bold;`, `초기 카메라 및 해상도 정보`);
+
+        debugLogEngine.log(this.name, '--- 해상도 정보 ---');
+        debugLogEngine.log(this.name, `게임 논리적 크기: ${config.width}x${config.height}`);
+        debugLogEngine.log(this.name, `기기 픽셀 비율(DPR): ${window.devicePixelRatio}`);
+        debugLogEngine.log(this.name, `최종 렌더링 해상도: ${config.width * config.resolution}x${config.height * config.resolution}`);
+
+        debugLogEngine.log(this.name, '--- 카메라 초기 상태 ---');
+        debugLogEngine.log(this.name, `초기 줌: ${camera.zoom}`);
+        debugLogEngine.log(this.name, `초기 스크롤(x, y): ${camera.scrollX}, ${camera.scrollY}`);
+        debugLogEngine.log(this.name, `월드 경계(w, h): ${camera.worldView.width}, ${camera.worldView.height}`);
+
+        console.groupEnd();
+    }
+
+    /**
+     * 카메라 연출에 대한 로그를 남깁니다.
+     * @param {string} action - 수행하는 연출 (예: '줌인', '흔들기')
+     * @param {object} details - 연출에 대한 상세 정보
+     */
+    logAction(action, details) {
+        debugLogEngine.log(this.name, `연출 시작: ${action}`, details);
+    }
+}
+
+// 유일한 인스턴스로 내보냅니다.
+export const debugCameraLogManager = new DebugCameraLogManager();

--- a/src/game/debug/DebugCombatLogManager.js
+++ b/src/game/debug/DebugCombatLogManager.js
@@ -1,8 +1,9 @@
 import { debugLogEngine } from '../utils/DebugLogEngine.js';
 
-class CombatLogManager {
+class DebugCombatLogManager {
     constructor() {
-        this.name = 'Combat';
+        // 이 매니저의 이름을 'DebugCombat'으로 정합니다.
+        this.name = 'DebugCombat';
         debugLogEngine.register(this);
     }
 
@@ -14,18 +15,19 @@ class CombatLogManager {
      * @param {number} finalDamage - 최종 데미지
      */
     logAttackCalculation(attacker, defender, baseDamage, finalDamage) {
-        console.groupCollapsed(`[${this.name}] ${attacker.name}이(가) ${defender.name}을(를) 공격!`);
-
+        console.groupCollapsed(`%c[${this.name}]`, `color: #d946ef; font-weight: bold;`, `${attacker.name}이(가) ${defender.name}을(를) 공격!`);
+        
         debugLogEngine.log(this.name, '--- 공격 상세 계산 ---');
         debugLogEngine.log(this.name, `공격자: ${attacker.name} (공격력: ${attacker.atk})`);
         debugLogEngine.log(this.name, `방어자: ${defender.name} (방어력: ${defender.def})`);
         debugLogEngine.log(this.name, `기본 데미지: ${baseDamage}`);
-        debugLogEngine.log(this.name, '데미지 공식: 기본 데미지 - 방어자 방어력');
+        debugLogEngine.log(this.name, `데미지 공식: 기본 데미지 - 방어자 방어력`);
         debugLogEngine.log(this.name, `계산: ${baseDamage} - ${defender.def} = ${finalDamage}`);
         debugLogEngine.log(this.name, `최종 적용 데미지: ${finalDamage}`);
-
+        
         console.groupEnd();
     }
 }
 
-export const combatLogManager = new CombatLogManager();
+// 내보내는 인스턴스 이름도 변경합니다.
+export const debugCombatLogManager = new DebugCombatLogManager();

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,6 +1,8 @@
 import { Scene } from "https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js";
 import { cameraEngine } from '../utils/CameraEngine.js';
 import { debugLogEngine } from '../utils/DebugLogEngine.js';
+import { debugCombatLogManager } from '../debug/DebugCombatLogManager.js';
+import { debugCameraLogManager } from '../debug/DebugCameraLogManager.js';
 
 export class Game extends Scene {
     constructor() {
@@ -14,6 +16,8 @@ export class Game extends Scene {
         // --- 1. 카메라 엔진에 현재 씬 등록 ---
         // 이 과정이 있어야 엔진이 어떤 카메라를 제어할지 알 수 있습니다.
         cameraEngine.registerScene(this);
+        // 게임 시작 시, 카메라의 초기 상태를 로그로 남깁니다.
+        debugCameraLogManager.logInitialState(this.cameras.main, this.sys.game.config);
 
         // --- 2. 테스트용 유닛(스프라이트) 생성 ---
         const warrior = this.add.sprite(250, 384, 'warrior').setInteractive();
@@ -25,6 +29,12 @@ export class Game extends Scene {
         if (!this.textures.exists('zombie')) {
             zombie.setTexture('warrior').setTint(0x88ff88);
         }
+
+        // 전투 로그 매니저 데모용 간단한 스탯 객체
+        const warriorStats = { name: '용맹한 전사', atk: 25, def: 10 };
+        const zombieStats = { name: '비틀거리는 좀비', atk: 15, def: 5 };
+        debugCombatLogManager.logAttackCalculation(warriorStats, zombieStats, 25, 20);
+        debugCombatLogManager.logAttackCalculation(zombieStats, warriorStats, 15, 5);
 
         // --- 3. 카메라 연출 실행 및 이벤트 연결 ---
         this.add.text(512, 50, '전사를 클릭하면 전투 연출이 시작됩니다.', {

--- a/src/game/utils/CameraEngine.js
+++ b/src/game/utils/CameraEngine.js
@@ -1,4 +1,4 @@
-import { debugLogEngine } from './DebugLogEngine.js';
+import { debugCameraLogManager } from '../debug/DebugCameraLogManager.js';
 
 /**
  * 게임 카메라의 복잡한 움직임과 연출을 담당하는 엔진 (싱글턴)
@@ -11,7 +11,7 @@ class CameraEngine {
         this.scene = null;
         this.camera = null;
 
-        debugLogEngine.log('CameraEngine', '카메라 엔진 초기화. 씬이 등록되기를 기다립니다...');
+        debugCameraLogManager.logAction('엔진 초기화', { message: '카메라 엔진 초기화. 씬이 등록되기를 기다립니다...' });
         CameraEngine.instance = this;
     }
     
@@ -23,7 +23,7 @@ class CameraEngine {
     registerScene(scene) {
         this.scene = scene;
         this.camera = scene.cameras.main;
-        debugLogEngine.log('CameraEngine', `[${scene.scene.key}] 씬의 카메라를 등록했습니다.`);
+        debugCameraLogManager.logAction('씬 등록', { scene: scene.scene.key });
     }
 
     /**
@@ -36,11 +36,11 @@ class CameraEngine {
     closeupOn(target, zoomLevel = 2, duration = 1000) {
         return new Promise(resolve => {
             if (!this.camera) {
-                debugLogEngine.error('CameraEngine', '카메라가 등록되지 않았습니다.');
+                console.error('CameraEngine', '카메라가 등록되지 않았습니다.');
                 return resolve();
             }
 
-            debugLogEngine.log('CameraEngine', `${target.name || '대상'}에 클로즈업합니다.`);
+            debugCameraLogManager.logAction('클로즈업', { target: target.name, zoom: zoomLevel, duration });
             
             // Pan(이동)과 Zoom(확대) 효과를 동시에 실행합니다.
             this.camera.pan(target.x, target.y, duration, 'Sine.easeInOut');
@@ -59,11 +59,11 @@ class CameraEngine {
     reset(duration = 1000) {
         return new Promise(resolve => {
             if (!this.camera) {
-                debugLogEngine.error('CameraEngine', '카메라가 등록되지 않았습니다.');
+                console.error('CameraEngine', '카메라가 등록되지 않았습니다.');
                 return resolve();
             }
-            
-            debugLogEngine.log('CameraEngine', '카메라를 원래 상태로 복원합니다.');
+
+            debugCameraLogManager.logAction('리셋', { duration });
             
             // 기본 줌 레벨(1)과 월드 중앙으로 되돌아갑니다.
             // Pan과 Zoom의 대상 좌표와 레벨은 게임에 맞게 수정할 수 있습니다.
@@ -83,9 +83,11 @@ class CameraEngine {
     shake(intensity = 0.01, duration = 200) {
         return new Promise(resolve => {
             if (!this.camera) {
-                debugLogEngine.error('CameraEngine', '카메라가 등록되지 않았습니다.');
+                console.error('CameraEngine', '카메라가 등록되지 않았습니다.');
                 return resolve();
             }
+
+            debugCameraLogManager.logAction('화면 흔들기', { duration, intensity });
 
             this.camera.shake(duration, intensity);
             


### PR DESCRIPTION
## Summary
- rename `CombatLogManager` to `DebugCombatLogManager`
- create `DebugCameraLogManager` for camera/resolution logging
- update `CameraEngine` to use the new camera log manager
- log initial camera state and combat calculations in `Game` scene

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687bbb6678408327872893fd82a98904