### PR TITLE
Add Territory scene and grid system

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -3,6 +3,8 @@ import { Game as MainGame } from './scenes/Game.js';
 import { GameOver } from './scenes/GameOver.js';
 import { MainMenu } from './scenes/MainMenu.js';
 import { Preloader } from './scenes/Preloader.js';
+// 영지 화면을 위한 TerritoryScene을 가져옵니다.
+import { TerritoryScene } from './scenes/TerritoryScene.js';
 // phaser 모듈을 직접 불러오면 로컬 서버에서 해석되지 않으므로
 // node_modules 경로를 상대 경로로 지정합니다.
 // Phaser를 CDN에서 불러와 배포 시 404 오류를 방지합니다.
@@ -24,8 +26,10 @@ const config = {
         autoCenter: Phaser.Scale.CENTER_BOTH
     },
     scene: [
+        // Boot, Preloader 이후 영지 씬을 먼저 보여줍니다.
         Boot,
         Preloader,
+        TerritoryScene,
         MainMenu,
         MainGame,
         GameOver

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -51,11 +51,14 @@ export class Preloader extends Scene
 
         // 게임 씬에서 사용할 전사 이미지를 로드합니다.
         this.load.image('warrior', 'images/unit/warrior.png');
+
+        // 영지 씬에 사용할 배경 이미지를 로드합니다.
+        this.load.image('city-1', 'images/territory/city-1.png');
     }
 
     create ()
     {
-        // 모든 애셋이 로드되면 메인 메뉴 씬으로 전환합니다.
-        this.scene.start('MainMenu');
+        // 모든 애셋이 로드되면 영지 씬으로 전환합니다.
+        this.scene.start('TerritoryScene');
     }
 }

--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -1,0 +1,38 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { GridEngine } from '../utils/GridEngine.js';
+import { cameraEngine } from '../utils/CameraEngine.js';
+
+export class TerritoryScene extends Scene {
+    constructor() {
+        super('TerritoryScene');
+    }
+
+    create() {
+        // 카메라 엔진에 현재 씬을 등록합니다.
+        cameraEngine.registerScene(this);
+
+        // 1. 영지 배경 이미지를 화면 중앙에 추가합니다.
+        const background = this.add.image(this.cameras.main.centerX, this.cameras.main.centerY, 'city-1');
+        // 화면 크기에 맞게 배경 이미지 크기를 조절할 수도 있습니다.
+        // background.setDisplaySize(this.cameras.main.width, this.cameras.main.height);
+
+        // 2. 그리드 엔진을 생성합니다.
+        this.gridEngine = new GridEngine(this);
+
+        // 3. 3x3 그리드를 생성합니다.
+        this.gridEngine.createGrid({
+            x: 180,
+            y: 250,
+            cols: 3,
+            rows: 3,
+            cellWidth: 220,
+            cellHeight: 150
+        });
+
+        // 4. 안내 텍스트
+        this.add.text(this.cameras.main.centerX, 50, '영지 화면', {
+            fontFamily: 'Arial Black', fontSize: 48, color: '#ffffff',
+            stroke: '#000000', strokeThickness: 8
+        }).setOrigin(0.5);
+    }
+}

--- a/src/game/utils/GridEngine.js
+++ b/src/game/utils/GridEngine.js
@@ -1,0 +1,60 @@
+import { debugLogEngine } from './DebugLogEngine.js';
+
+/**
+ * 게임 내 그리드 시스템을 생성하고 관리하는 엔진
+ */
+export class GridEngine {
+    constructor(scene) {
+        this.scene = scene;
+        this.gridCells = []; // 그리드 각 칸의 정보를 저장할 배열
+        debugLogEngine.log('GridEngine', '그리드 엔진 생성됨.');
+    }
+
+    /**
+     * 지정된 크기와 위치에 그리드를 생성합니다.
+     * @param {number} x - 그리드가 시작될 x 좌표
+     * @param {number} y - 그리드가 시작될 y 좌표
+     * @param {number} cols - 그리드의 열 개수
+     * @param {number} rows - 그리드의 행 개수
+     * @param {number} cellWidth - 각 칸의 너비
+     * @param {number} cellHeight - 각 칸의 높이
+     */
+    createGrid({ x, y, cols, rows, cellWidth, cellHeight }) {
+        debugLogEngine.log('GridEngine', `${cols}x${rows} 그리드를 생성합니다.`);
+
+        // 디버깅 목적으로 그리드를 시각적으로 표시할 그래픽스 객체
+        const graphics = this.scene.add.graphics({ lineStyle: { width: 2, color: 0x00ff00, alpha: 0.5 } });
+
+        for (let row = 0; row < rows; row++) {
+            for (let col = 0; col < cols; col++) {
+                const cellX = x + col * cellWidth;
+                const cellY = y + row * cellHeight;
+
+                // 각 칸의 정보를 객체로 만들어 배열에 저장
+                const cell = {
+                    x: cellX + cellWidth / 2,
+                    y: cellY + cellHeight / 2,
+                    width: cellWidth,
+                    height: cellHeight,
+                    col: col,
+                    row: row,
+                    isOccupied: false
+                };
+                this.gridCells.push(cell);
+
+                // 디버깅용 사각형을 그립니다. 나중에 이 부분만 주석 처리하면 보이지 않게 됩니다.
+                graphics.strokeRect(cellX, cellY, cellWidth, cellHeight);
+            }
+        }
+    }
+
+    /**
+     * 특정 열과 행에 해당하는 칸의 정보를 반환합니다.
+     * @param {number} col - 찾을 칸의 열
+     * @param {number} row - 찾을 칸의 행
+     * @returns {object|undefined} 찾은 칸의 정보 객체
+     */
+    getCell(col, row) {
+        return this.gridCells.find(cell => cell.col === col && cell.row === row);
+    }
+}


### PR DESCRIPTION
## Summary
- load `city-1` territory image in Preloader
- create `GridEngine` utility to handle grid creation
- implement new `TerritoryScene`
- start game in `TerritoryScene` and include it in config

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bbf8f070083278b8662ba39bf7ed8