### PR TITLE
Implement tooltip and animation utilities

### DIFF
--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -54,6 +54,9 @@ export class Preloader extends Scene
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
+
+        // 여관 아이콘 이미지를 로드합니다.
+        this.load.image('tavern-icon', 'images/territory/tavern-icon.png');
     }
 
     create ()

--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -1,5 +1,7 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { GridEngine } from '../utils/GridEngine.js';
+import { UIEngine } from '../utils/UIEngine.js';
+import { AnimationEngine } from '../utils/AnimationEngine.js';
 import { cameraEngine } from '../utils/CameraEngine.js';
 
 export class TerritoryScene extends Scene {
@@ -8,28 +10,54 @@ export class TerritoryScene extends Scene {
     }
 
     create() {
-        // 카메라 엔진에 현재 씬을 등록합니다.
         cameraEngine.registerScene(this);
-
-        // 1. 영지 배경 이미지를 화면 중앙에 추가합니다.
         const background = this.add.image(this.cameras.main.centerX, this.cameras.main.centerY, 'city-1');
-        // 화면 크기에 맞게 배경 이미지 크기를 조절할 수도 있습니다.
-        // background.setDisplaySize(this.cameras.main.width, this.cameras.main.height);
-
-        // 2. 그리드 엔진을 생성합니다.
+        
+        // --- 1. 엔진들 생성 ---
         this.gridEngine = new GridEngine(this);
+        this.uiEngine = new UIEngine(this);
+        this.animationEngine = new AnimationEngine(this);
 
-        // 3. 3x3 그리드를 생성합니다.
         this.gridEngine.createGrid({
-            x: 180,
-            y: 250,
-            cols: 3,
-            rows: 3,
-            cellWidth: 220,
-            cellHeight: 150
+            x: 180, y: 250, cols: 3, rows: 3,
+            cellWidth: 220, cellHeight: 150
         });
 
-        // 4. 안내 텍스트
+        // --- 2. 그리드에 여관 아이콘 추가 ---
+        // (0, 0) 위치, 즉 첫 번째 칸의 정보를 가져옵니다.
+        const firstCell = this.gridEngine.getCell(0, 0);
+        if (firstCell) {
+            // 해당 칸의 중앙 좌표에 여관 아이콘 스프라이트를 추가합니다.
+            const tavernIcon = this.add.sprite(firstCell.x, firstCell.y, 'tavern-icon');
+            
+            // 아이콘이 마우스 입력을 받을 수 있도록 설정합니다.
+            tavernIcon.setInteractive();
+
+            // --- 3. 마우스 이벤트 연결 ---
+            
+            // 마우스 커서가 아이콘 위에 올라갔을 때
+            tavernIcon.on('pointerover', () => {
+                // UI 엔진을 사용해 툴팁을 표시합니다.
+                this.uiEngine.showTooltip(tavernIcon.x, tavernIcon.y, '[여관]');
+                // 애니메이션 엔진을 사용해 아이콘을 확대합니다.
+                this.animationEngine.scaleUp(tavernIcon, 1.1);
+            });
+
+            // 마우스 커서가 아이콘에서 벗어났을 때
+            tavernIcon.on('pointerout', () => {
+                // 툴팁을 숨깁니다.
+                this.uiEngine.hideTooltip();
+                // 아이콘을 원래 크기로 되돌립니다.
+                this.animationEngine.scaleDown(tavernIcon, 1.0);
+            });
+
+            // 아이콘을 클릭했을 때
+            tavernIcon.on('pointerdown', () => {
+                console.log('여관을 클릭했습니다!');
+                // 여기에 나중에 여관 화면으로 이동하는 코드를 추가할 수 있습니다.
+            });
+        }
+        
         this.add.text(this.cameras.main.centerX, 50, '영지 화면', {
             fontFamily: 'Arial Black', fontSize: 48, color: '#ffffff',
             stroke: '#000000', strokeThickness: 8

--- a/src/game/utils/AnimationEngine.js
+++ b/src/game/utils/AnimationEngine.js
@@ -1,0 +1,38 @@
+/**
+ * 간단한 애니메이션 효과를 담당하는 엔진
+ */
+export class AnimationEngine {
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    /**
+     * 대상을 확대하는 애니메이션
+     * @param {Phaser.GameObjects.GameObject} target - 애니메이션을 적용할 대상
+     * @param {number} scale - 최종 확대 크기
+     * @param {number} duration - 애니메이션 시간 (밀리초)
+     */
+    scaleUp(target, scale = 1.2, duration = 100) {
+        this.scene.tweens.add({
+            targets: target,
+            scale: scale,
+            duration: duration,
+            ease: 'Sine.easeInOut'
+        });
+    }
+
+    /**
+     * 대상을 원래 크기로 축소하는 애니메이션
+     * @param {Phaser.GameObjects.GameObject} target - 애니메이션을 적용할 대상
+     * @param {number} scale - 원래 크기
+     * @param {number} duration - 애니메이션 시간 (밀리초)
+     */
+    scaleDown(target, scale = 1.0, duration = 100) {
+        this.scene.tweens.add({
+            targets: target,
+            scale: scale,
+            duration: duration,
+            ease: 'Sine.easeInOut'
+        });
+    }
+}

--- a/src/game/utils/UIEngine.js
+++ b/src/game/utils/UIEngine.js
@@ -1,0 +1,40 @@
+/**
+ * 게임 내 간단한 UI 요소(툴팁 등)를 관리하는 엔진
+ */
+export class UIEngine {
+    constructor(scene) {
+        this.scene = scene;
+        this.tooltip = null;
+    }
+
+    /**
+     * 화면에 툴팁을 표시합니다.
+     * @param {number} x - 툴팁이 표시될 x 좌표
+     * @param {number} y - 툴팁이 표시될 y 좌표
+     * @param {string} text - 툴팁에 표시될 텍스트
+     */
+    showTooltip(x, y, text) {
+        // 이미 툴팁이 있다면 제거
+        if (this.tooltip) {
+            this.hideTooltip();
+        }
+
+        this.tooltip = this.scene.add.text(x, y, text, {
+            fontFamily: 'Arial',
+            fontSize: '18px',
+            color: '#ffffff',
+            backgroundColor: 'rgba(0,0,0,0.7)',
+            padding: { x: 8, y: 4 },
+        }).setOrigin(0.5, 1.2); // 텍스트의 기준점을 대상의 위쪽 중앙으로 설정
+    }
+
+    /**
+     * 화면에서 툴팁을 제거합니다.
+     */
+    hideTooltip() {
+        if (this.tooltip) {
+            this.tooltip.destroy();
+            this.tooltip = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load tavern icon in Preloader
- add UIEngine for tooltips
- add AnimationEngine for simple tweens
- enhance TerritoryScene with tavern icon interactivity

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bc1e137d083279cbf9eeacb8f2721