### PR TITLE
Refactor territory to DOM engine

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -38,3 +38,50 @@ body {
     /* 사용자가 텍스트를 선택할 수 없도록 하여 더블클릭 시 불편함을 줄입니다. */
     user-select: none;
 }
+
+/* --- 영지 화면 DOM 스타일 --- */
+
+/* 영지 화면 전체를 감싸는 컨테이너 */
+#territory-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
+/* 영지 배경 이미지 */
+#territory-background {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* 그리드 컨테이너 (CSS Grid 사용) */
+#territory-grid {
+    position: absolute;
+    display: grid;
+    gap: 10px;
+}
+
+/* 그리드 각 칸(건물 아이콘)의 스타일 */
+.building-icon {
+    width: 100%;
+    height: 100%;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    cursor: pointer;
+    transition: transform 0.1s ease-in-out;
+
+    image-rendering: -moz-crisp-edges;
+    image-rendering: -webkit-crisp-edges;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+}
+
+/* 아이콘 위에 마우스를 올렸을 때의 스타일 */
+.building-icon:hover {
+    transform: scale(1.1);
+}

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -1,0 +1,96 @@
+import { surveyEngine } from '../utils/SurveyEngine.js';
+import { DOMEngine } from '../utils/DOMEngine.js'; // 툴팁 기능을 위해 DOMEngine 참조
+
+/**
+ * 영지 화면의 모든 DOM 요소를 생성하고 관리하는 전용 엔진
+ */
+export class TerritoryDOMEngine {
+    constructor(scene, domEngine) {
+        this.scene = scene;
+        this.domEngine = domEngine; // 툴팁 표시를 위해 DOMEngine 인스턴스를 받음
+        this.container = null;
+        this.grid = null;
+
+        this.createTerritory();
+    }
+
+    createTerritory() {
+        const app = document.getElementById('app');
+
+        // 1. 영지 전체 컨테이너 생성
+        this.container = document.createElement('div');
+        this.container.id = 'territory-container';
+        
+        // 2. 배경 이미지 생성
+        const background = document.createElement('img');
+        background.id = 'territory-background';
+        background.src = 'assets/images/territory/city-1.png';
+        background.classList.add('building-icon');
+        
+        // 3. 그리드 컨테이너 생성
+        this.grid = document.createElement('div');
+        this.grid.id = 'territory-grid';
+        this.setupGridStyle();
+
+        this.container.appendChild(background);
+        this.container.appendChild(this.grid);
+        app.appendChild(this.container);
+
+        // 첫 번째 칸에 여관 추가
+        this.addBuilding(0, 0, 'tavern-icon', '[여관]');
+    }
+
+    // SurveyEngine의 값을 기반으로 그리드의 CSS를 설정
+    setupGridStyle() {
+        const gridConfig = surveyEngine.territoryGrid;
+        const canvasConfig = surveyEngine.canvas;
+
+        // 게임 캔버스 크기에 대한 실제 화면 크기의 비율을 계산
+        const scaleRatio = Math.min(
+            window.innerWidth / canvasConfig.width, 
+            window.innerHeight / canvasConfig.height
+        );
+
+        this.grid.style.top = `${gridConfig.y * scaleRatio}px`;
+        this.grid.style.left = `${gridConfig.x * scaleRatio}px`;
+        this.grid.style.width = `${gridConfig.cols * gridConfig.cellWidth * scaleRatio}px`;
+        this.grid.style.height = `${gridConfig.rows * gridConfig.cellHeight * scaleRatio}px`;
+        
+        this.grid.style.gridTemplateColumns = `repeat(${gridConfig.cols}, 1fr)`;
+        this.grid.style.gridTemplateRows = `repeat(${gridConfig.rows}, 1fr)`;
+    }
+
+    /**
+     * 그리드에 건물을 추가합니다.
+     * @param {number} col - 건물이 위치할 열
+     * @param {number} row - 건물이 위치할 행
+     * @param {string} iconId - 사용할 아이콘 이미지의 ID (애셋 키)
+     * @param {string} tooltipText - 표시할 툴팁 텍스트
+     */
+    addBuilding(col, row, iconId, tooltipText) {
+        const icon = document.createElement('div');
+        icon.className = 'building-icon';
+        icon.style.backgroundImage = `url(assets/images/territory/${iconId}.png)`;
+        
+        // 마우스 이벤트 연결
+        icon.addEventListener('mouseover', (event) => {
+            // DOMEngine의 툴팁 기능을 사용 (DOM 좌표를 직접 넘겨줌)
+            this.domEngine.showTooltip(event.clientX, event.clientY, tooltipText);
+        });
+
+        icon.addEventListener('mouseout', () => {
+            this.domEngine.hideTooltip();
+        });
+
+        icon.addEventListener('click', () => {
+            console.log(`${tooltipText} 건물을 클릭했습니다.`);
+        });
+
+        this.grid.appendChild(icon);
+    }
+
+    // 씬이 종료될 때 모든 DOM 요소를 제거
+    destroy() {
+        this.container.remove();
+    }
+}

--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -1,11 +1,6 @@
-import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-import { GridEngine } from '../utils/GridEngine.js';
-// import { UIEngine } from '../utils/UIEngine.js';
+import { Scene } from 'phaser';
 import { DOMEngine } from '../utils/DOMEngine.js';
-import { AnimationEngine } from '../utils/AnimationEngine.js';
-import { cameraEngine } from '../utils/CameraEngine.js';
-// 측량 엔진을 import 합니다.
-import { surveyEngine } from '../utils/SurveyEngine.js';
+import { TerritoryDOMEngine } from '../dom/TerritoryDOMEngine.js';
 
 export class TerritoryScene extends Scene {
     constructor() {
@@ -13,50 +8,16 @@ export class TerritoryScene extends Scene {
     }
 
     create() {
-        cameraEngine.registerScene(this);
-        const background = this.add.image(this.cameras.main.centerX, this.cameras.main.centerY, 'city-1');
-
-        this.gridEngine = new GridEngine(this);
-        this.domEngine = new DOMEngine(this);
-        this.animationEngine = new AnimationEngine(this);
-
-        // --- 1. SurveyEngine의 값을 사용하여 그리드 생성 ---
-        // 이제 모든 그리드 정보는 surveyEngine이 관리합니다.
-        this.gridEngine.createGrid(surveyEngine.territoryGrid);
-
-        const firstCell = this.gridEngine.getCell(0, 0);
-        if (firstCell) {
-            const tavernIcon = this.add.sprite(firstCell.x, firstCell.y, 'tavern-icon');
-            
-            // --- 2. 아이콘 크기를 그리드 셀에 맞게 동적으로 조절 ---
-            const iconSize = firstCell.height * surveyEngine.buildingIcon.scaleToCell;
-            tavernIcon.setDisplaySize(iconSize, iconSize);
-
-            // --- 3. 상호작용 설정 (이 부분은 이전과 동일) ---
-            tavernIcon.setInteractive();
-
-            tavernIcon.on('pointerover', () => {
-                this.domEngine.showTooltip(tavernIcon.x, tavernIcon.y, '[여관]');
-                this.animationEngine.scaleUp(tavernIcon, 1.1);
-            });
-
-            tavernIcon.on('pointerout', () => {
-                this.domEngine.hideTooltip();
-                this.animationEngine.scaleDown(tavernIcon, 1.0);
-            });
-
-            tavernIcon.on('pointerdown', () => {
-                console.log('여관을 클릭했습니다!');
-            });
-        }
+        // 중요: 이제 이 씬은 비어있습니다.
+        // 모든 시각적 요소는 DOM 엔진들이 담당합니다.
         
-        const titleTarget = new Phaser.GameObjects.Sprite(this, this.cameras.main.centerX, 50, null);
-        this.domEngine.createSyncedText(titleTarget, '영지 화면', {
-            fontFamily: 'Arial Black',
-            fontSize: '48px',
-            color: '#ffffff',
-            textShadow: '2px 2px 4px #000000',
-            transform: 'translateX(-50%)'
+        // DOM 엔진들을 초기화합니다.
+        const domEngine = new DOMEngine(this);
+        const territoryDomEngine = new TerritoryDOMEngine(this, domEngine);
+
+        // 씬이 종료될 때 DOM 요소들을 정리하도록 이벤트를 설정합니다.
+        this.events.on('shutdown', () => {
+            territoryDomEngine.destroy();
         });
     }
 }

--- a/src/game/utils/DOMEngine.js
+++ b/src/game/utils/DOMEngine.js
@@ -50,31 +50,30 @@ export class DOMEngine {
     showTooltip(x, y, text) {
         if (this.tooltip) this.hideTooltip();
 
-        // 툴팁을 위한 임시 게임 오브젝트를 생성하여 동기화
-        const tempTarget = new Phaser.GameObjects.Sprite(this.scene, x, y, null);
+        this.tooltip = document.createElement('div');
+        this.tooltip.innerText = text;
 
         const style = {
+            position: 'absolute',
+            left: `${x}px`,
+            top: `${y}px`,
             fontSize: '18px',
             color: '#ffffff',
             backgroundColor: 'rgba(0,0,0,0.7)',
             padding: '4px 8px',
             borderRadius: '4px',
-            transform: 'translate(-50%, -150%)'
+            transform: 'translate(10px, -100%)',
+            pointerEvents: 'none',
+            zIndex: '10000'
         };
+        Object.assign(this.tooltip.style, style);
 
-        this.tooltip = this.createSyncedText(tempTarget, text, style);
-        this.tooltip.syncTarget = tempTarget; // 임시 타겟 저장
+        this.uiContainer.appendChild(this.tooltip);
     }
 
     hideTooltip() {
         if (this.tooltip) {
-            const syncInstance = this.activeSyncs.find(s => s.domElement === this.tooltip);
-            if (syncInstance) {
-                syncInstance.destroy();
-                // activeSyncs 배열에서 제거
-                this.activeSyncs = this.activeSyncs.filter(s => s !== syncInstance);
-            }
-            this.tooltip.syncTarget.destroy();
+            this.tooltip.remove();
             this.tooltip = null;
         }
     }


### PR DESCRIPTION
## Summary
- add DOM styles for territory screen
- implement `TerritoryDOMEngine` for DOM-based rendering
- simplify `TerritoryScene` to use DOM engines only
- adjust `DOMEngine` tooltip logic for direct coordinates

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687bd8122aa88327a3ea8022165dd7cd