### PR TITLE
Fix Phaser import path

### DIFF
--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -1,4 +1,5 @@
-import { Scene } from 'phaser';
+// Phaser 모듈을 CDN에서 가져와 브라우저에서 직접 실행될 때 모듈 해석 오류를 방지합니다.
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
 import { TerritoryDOMEngine } from '../dom/TerritoryDOMEngine.js';
 


### PR DESCRIPTION
## Summary
- load Phaser from CDN in `TerritoryScene` to avoid module resolution error

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bde2e49b48327959d36f6900cf161