### PR TITLE
Add resolution debug manager

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -75,9 +75,10 @@ body {
     cursor: pointer;
     transition: transform 0.1s ease-in-out;
 
-    image-rendering: -moz-crisp-edges;
-    image-rendering: -webkit-crisp-edges;
-    image-rendering: pixelated;
+    /* --- 중요: 이미지 뭉개짐 방지 (픽셀 선명하게) --- */
+    image-rendering: -moz-crisp-edges;      /* Firefox */
+    image-rendering: -webkit-crisp-edges;   /* Webkit (Chrome, Safari) */
+    image-rendering: pixelated;             /* W3C 표준 */
     image-rendering: crisp-edges;
 }
 

--- a/src/game/debug/DebugResolutionLogManager.js
+++ b/src/game/debug/DebugResolutionLogManager.js
@@ -1,0 +1,30 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugResolutionLogManager {
+    constructor() {
+        this.name = 'DebugResolution';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 현재 해상도 관련 정보를 콘솔에 그룹화하여 출력합니다.
+     * @param {Phaser.Game} game - Phaser 게임 인스턴스
+     */
+    logResolution(game) {
+        const config = game.config;
+        const canvas = game.canvas;
+
+        console.groupCollapsed(`%c[${this.name}]`, `color: #1d4ed8; font-weight: bold;`, `현재 해상도 정보`);
+
+        debugLogEngine.log(this.name, '--- 논리적 크기 (게임 월드 기준) ---');
+        debugLogEngine.log(this.name, `Game Config: ${config.width}x${config.height}`);
+
+        debugLogEngine.log(this.name, '--- 물리적 크기 (실제 렌더링 기준) ---');
+        debugLogEngine.log(this.name, `Device Pixel Ratio: ${window.devicePixelRatio}`);
+        debugLogEngine.log(this.name, `Phaser Canvas: ${canvas.width}x${canvas.height} (논리적 크기 * DPR)`);
+
+        console.groupEnd();
+    }
+}
+
+export const debugResolutionLogManager = new DebugResolutionLogManager();

--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -2,6 +2,8 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
 import { TerritoryDOMEngine } from '../dom/TerritoryDOMEngine.js';
+// 새로 만든 해상도 로그 매니저를 import 합니다.
+import { debugResolutionLogManager } from '../debug/DebugResolutionLogManager.js';
 
 export class TerritoryScene extends Scene {
     constructor() {
@@ -15,6 +17,10 @@ export class TerritoryScene extends Scene {
         // DOM 엔진들을 초기화합니다.
         const domEngine = new DOMEngine(this);
         const territoryDomEngine = new TerritoryDOMEngine(this, domEngine);
+
+        // --- 중요: 해상도 정보 로그 출력 ---
+        // 게임이 시작될 때 현재 해상도 정보를 콘솔에 기록합니다.
+        debugResolutionLogManager.logResolution(this.sys.game);
 
         // 씬이 종료될 때 DOM 요소들을 정리하도록 이벤트를 설정합니다.
         this.events.on('shutdown', () => {


### PR DESCRIPTION
## Summary
- add a new `DebugResolutionLogManager` to log resolution info
- log resolution when `TerritoryScene` starts
- document crisp image rendering in CSS

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`
- `npm install`
- `npm run build-nolog`

------
https://chatgpt.com/codex/tasks/task_e_687bec5209748327a34934f114ee51b9