### PR TITLE
Fix icon and canvas pixelation

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -78,7 +78,7 @@ body {
     /* --- 중요: 이미지 뭉개짐 방지 (픽셀 선명하게) --- */
     image-rendering: -moz-crisp-edges;      /* Firefox */
     image-rendering: -webkit-crisp-edges;   /* Webkit (Chrome, Safari) */
-    image-rendering: pixelated;             /* W3C 표준 */
+    image-rendering: pixelated !important;             /* W3C 표준 */
     image-rendering: crisp-edges;
 }
 

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -22,6 +22,9 @@ const config = {
     height: surveyEngine.canvas.height,
     parent: 'game-container',
     backgroundColor: '#000000',
+    // --- 수정 및 추가 ---
+    pixelArt: true, // 픽셀 아트 모드를 활성화하여 뭉개짐을 방지합니다.
+
     // 기기의 픽셀 비율에 따라 해상도를 자동으로 조정합니다.
     resolution: window.devicePixelRatio || 1,
     scale: {


### PR DESCRIPTION
## Summary
- enable Phaser pixelArt mode for clearer canvas rendering
- enforce pixelated rendering for DOM icons

## Testing
- `python3 -m http.server 8000` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687beed59fac8327896fd4effdf357da