### PR TITLE
Layer DOM territory above Phaser canvas

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -49,6 +49,7 @@ body {
     width: 100%;
     height: 100%;
     overflow: hidden;
+    z-index: 10; /* Phaser 캔버스보다 높은 숫자를 주어 위로 올립니다. */
 }
 
 /* 영지 배경 이미지 */
@@ -85,4 +86,10 @@ body {
 /* 아이콘 위에 마우스를 올렸을 때의 스타일 */
 .building-icon:hover {
     transform: scale(1.1);
+}
+
+/* Phaser 게임 캔버스를 담는 컨테이너 */
+#game-container {
+    position: absolute;
+    z-index: 1; /* DOM 영지보다 낮은 숫자를 주어 아래로 내립니다. */
 }

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -21,7 +21,8 @@ const config = {
     width: surveyEngine.canvas.width,
     height: surveyEngine.canvas.height,
     parent: 'game-container',
-    backgroundColor: '#000000',
+    backgroundColor: 'transparent', // 배경색을 투명하게
+    transparent: true, // 캔버스 자체를 투명하게 설정
     // --- 수정 및 추가 ---
     pixelArt: true, // 픽셀 아트 모드를 활성화하여 뭉개짐을 방지합니다.
 


### PR DESCRIPTION
## Summary
- overlay the DOM territory container above the Phaser canvas via `z-index`
- add a lower `z-index` for the Phaser canvas container
- make the Phaser canvas transparent to keep DOM controls visible

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bf1eb90048327bbb1a0748ab43e66