### PR TITLE
Simplify Territory DOM layer

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -11,6 +11,7 @@
 <body>
     <div id="app">
         <div id="game-container"></div>
+        <div id="territory-container"></div>
         <div id="ui-container"></div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 <body>
     <div id="app">
         <div id="game-container"></div>
+        <div id="territory-container"></div>
         <div id="ui-container"></div>
     </div>
     <script type="module" src="src/main.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -39,34 +39,49 @@ body {
     user-select: none;
 }
 
-/* --- 영지 화면 DOM 스타일 --- */
+/* --- 영지 화면 DOM 스타일 (수정된 버전) --- */
 
-/* 영지 화면 전체를 감싸는 컨테이너 */
 #territory-container {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    overflow: hidden;
-    z-index: 10; /* Phaser 캔버스보다 높은 숫자를 주어 위로 올립니다. */
+    z-index: 10;
+    /* 포인터 이벤트가 하위 요소로 전달되도록 설정 */
+    pointer-events: none; 
 }
 
-/* 영지 배경 이미지 */
-#territory-background {
+/* 배경 이미지는 이제 가상 요소를 사용해 독립적으로 배치 */
+#territory-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    background-image: url(../assets/images/territory/city-1.png);
+    background-size: cover;
+    background-position: center;
+    /* 아이콘이 보일 수 있도록 배경의 z-index를 낮춤 */
+    z-index: -1; 
 }
 
-/* 그리드 컨테이너 (CSS Grid 사용) */
 #territory-grid {
     position: absolute;
+    /* surveyEngine 값에 따라 JS가 아닌 CSS 변수로 제어 (나중에 확장 가능) */
+    /* 지금은 하드코딩으로 가장 보기 좋은 위치에 배치합니다. */
+    top: 35%;
+    left: 15%;
+    width: 40%;
+    height: 50%;
+
     display: grid;
-    gap: 10px;
+    gap: 15px; /* 칸 사이의 간격 */
+    /* 이제부터는 하위 요소들이 포인터 이벤트를 받을 수 있음 */
+    pointer-events: auto;
 }
 
-/* 그리드 각 칸(건물 아이콘)의 스타일 */
 .building-icon {
     width: 100%;
     height: 100%;
@@ -76,14 +91,13 @@ body {
     cursor: pointer;
     transition: transform 0.1s ease-in-out;
 
-    /* --- 중요: 이미지 뭉개짐 방지 (픽셀 선명하게) --- */
-    image-rendering: -moz-crisp-edges;      /* Firefox */
-    image-rendering: -webkit-crisp-edges;   /* Webkit (Chrome, Safari) */
-    image-rendering: pixelated !important;             /* W3C 표준 */
+    /* --- 이미지 뭉개짐 방지 --- */
+    image-rendering: -moz-crisp-edges;
+    image-rendering: -webkit-crisp-edges;
+    image-rendering: pixelated !important;
     image-rendering: crisp-edges;
 }
 
-/* 아이콘 위에 마우스를 올렸을 때의 스타일 */
 .building-icon:hover {
     transform: scale(1.1);
 }

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -1,80 +1,41 @@
 import { surveyEngine } from '../utils/SurveyEngine.js';
-import { DOMEngine } from '../utils/DOMEngine.js'; // 툴팁 기능을 위해 DOMEngine 참조
+import { DOMEngine } from '../utils/DOMEngine.js';
 
 /**
- * 영지 화면의 모든 DOM 요소를 생성하고 관리하는 전용 엔진
+ * 영지 화면의 DOM 요소를 생성하고 관리하는 전용 엔진 (수정된 버전)
  */
 export class TerritoryDOMEngine {
     constructor(scene, domEngine) {
-        this.scene = scene;
-        this.domEngine = domEngine; // 툴팁 표시를 위해 DOMEngine 인스턴스를 받음
-        this.container = null;
+        this.domEngine = domEngine;
+        this.container = document.getElementById('territory-container');
         this.grid = null;
 
-        this.createTerritory();
-    }
-
-    createTerritory() {
-        const app = document.getElementById('app');
-
-        // 1. 영지 전체 컨테이너 생성
-        this.container = document.createElement('div');
-        this.container.id = 'territory-container';
-        
-        // 2. 배경 이미지 생성
-        const background = document.createElement('img');
-        background.id = 'territory-background';
-        background.src = 'assets/images/territory/city-1.png';
-        background.classList.add('building-icon');
-        
-        // 3. 그리드 컨테이너 생성
-        this.grid = document.createElement('div');
-        this.grid.id = 'territory-grid';
-        this.setupGridStyle();
-
-        this.container.appendChild(background);
-        this.container.appendChild(this.grid);
-        app.appendChild(this.container);
-
-        // 첫 번째 칸에 여관 추가
+        this.createGrid();
         this.addBuilding(0, 0, 'tavern-icon', '[여관]');
     }
 
-    // SurveyEngine의 값을 기반으로 그리드의 CSS를 설정
-    setupGridStyle() {
+    createGrid() {
+        this.grid = document.createElement('div');
+        this.grid.id = 'territory-grid';
+
+        // surveyEngine의 값을 사용해 그리드 스타일을 설정
         const gridConfig = surveyEngine.territoryGrid;
-        const canvasConfig = surveyEngine.canvas;
-
-        // 게임 캔버스 크기에 대한 실제 화면 크기의 비율을 계산
-        const scaleRatio = Math.min(
-            window.innerWidth / canvasConfig.width, 
-            window.innerHeight / canvasConfig.height
-        );
-
-        this.grid.style.top = `${gridConfig.y * scaleRatio}px`;
-        this.grid.style.left = `${gridConfig.x * scaleRatio}px`;
-        this.grid.style.width = `${gridConfig.cols * gridConfig.cellWidth * scaleRatio}px`;
-        this.grid.style.height = `${gridConfig.rows * gridConfig.cellHeight * scaleRatio}px`;
-        
         this.grid.style.gridTemplateColumns = `repeat(${gridConfig.cols}, 1fr)`;
         this.grid.style.gridTemplateRows = `repeat(${gridConfig.rows}, 1fr)`;
+        
+        this.container.appendChild(this.grid);
     }
-
-    /**
-     * 그리드에 건물을 추가합니다.
-     * @param {number} col - 건물이 위치할 열
-     * @param {number} row - 건물이 위치할 행
-     * @param {string} iconId - 사용할 아이콘 이미지의 ID (애셋 키)
-     * @param {string} tooltipText - 표시할 툴팁 텍스트
-     */
+    
     addBuilding(col, row, iconId, tooltipText) {
         const icon = document.createElement('div');
         icon.className = 'building-icon';
         icon.style.backgroundImage = `url(assets/images/territory/${iconId}.png)`;
         
-        // 마우스 이벤트 연결
+        // CSS Grid의 위치 지정 (col, row 인덱스는 1부터 시작)
+        icon.style.gridColumnStart = col + 1;
+        icon.style.gridRowStart = row + 1;
+
         icon.addEventListener('mouseover', (event) => {
-            // DOMEngine의 툴팁 기능을 사용 (DOM 좌표를 직접 넘겨줌)
             this.domEngine.showTooltip(event.clientX, event.clientY, tooltipText);
         });
 
@@ -89,8 +50,7 @@ export class TerritoryDOMEngine {
         this.grid.appendChild(icon);
     }
 
-    // 씬이 종료될 때 모든 DOM 요소를 제거
     destroy() {
-        this.container.remove();
+        this.container.innerHTML = ''; // 간단하게 내용만 비움
     }
 }


### PR DESCRIPTION
## Summary
- simplify `TerritoryDOMEngine` to only create required DOM elements
- control layout purely via CSS
- insert `territory-container` into the HTML layout

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687bfff3be208327a5ec6bddfff3905c