### PR TITLE
Adjust rendering settings for smoother graphics

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -91,11 +91,7 @@ body {
     cursor: pointer;
     transition: transform 0.1s ease-in-out;
 
-    /* --- 이미지 뭉개짐 방지 --- */
-    image-rendering: -moz-crisp-edges;
-    image-rendering: -webkit-crisp-edges;
-    image-rendering: pixelated !important;
-    image-rendering: crisp-edges;
+    /* 이미지를 부드럽게 표시하기 위해 별도의 렌더링 옵션을 사용하지 않습니다. */
 }
 
 .building-icon:hover {

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -23,10 +23,6 @@ const config = {
     parent: 'game-container',
     backgroundColor: 'transparent', // 배경색을 투명하게
     transparent: true, // 캔버스 자체를 투명하게 설정
-    // --- 수정 및 추가 ---
-    pixelArt: true, // 픽셀 아트 모드를 활성화하여 뭉개짐을 방지합니다.
-
-    // 기기의 픽셀 비율에 따라 해상도를 자동으로 조정합니다.
     resolution: window.devicePixelRatio || 1,
     scale: {
         mode: Phaser.Scale.FIT,


### PR DESCRIPTION
## Summary
- disable Phaser's pixelArt option to allow anti-aliasing
- remove `image-rendering` from `.building-icon` so icons render smoothly

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687c75d799008327898a7437222bd2fd