### PR TITLE
Add tavern UI and hiring modal

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -48,23 +48,10 @@ body {
     width: 100%;
     height: 100%;
     z-index: 10;
-    /* 포인터 이벤트가 하위 요소로 전달되도록 설정 */
-    pointer-events: none; 
-}
-
-/* 배경 이미지는 이제 가상 요소를 사용해 독립적으로 배치 */
-#territory-container::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-image: url(../assets/images/territory/city-1.png);
+    pointer-events: none;
     background-size: cover;
     background-position: center;
-    /* 아이콘이 보일 수 있도록 배경의 z-index를 낮춤 */
-    z-index: -1; 
+    background-image: url(../assets/images/territory/city-1.png);
 }
 
 #territory-grid {
@@ -96,6 +83,97 @@ body {
 
 .building-icon:hover {
     transform: scale(1.1);
+}
+
+/* --- 선술집 뷰 스타일 --- */
+#tavern-view {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    pointer-events: auto;
+}
+
+#tavern-grid {
+    position: absolute;
+    bottom: 5%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80%;
+    height: 25%;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+}
+
+.tavern-button {
+    width: 100%;
+    height: 100%;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.tavern-button:hover {
+    transform: scale(1.05);
+    filter: brightness(1.2);
+}
+
+/* --- 용병 고용 모달 스타일 --- */
+#hire-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    pointer-events: auto;
+}
+
+#hire-modal-content {
+    position: relative;
+    background-color: #1a1a1a;
+    padding: 20px;
+    border-radius: 10px;
+    border: 2px solid #444;
+    box-shadow: 0 0 20px rgba(0,0,0,0.5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#hire-modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 24px;
+    color: #fff;
+    cursor: pointer;
+}
+
+#hire-image-viewer {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+#mercenary-image {
+    max-width: 400px;
+    max-height: 600px;
+    border-radius: 5px;
+}
+
+.hire-arrow {
+    font-size: 40px;
+    color: #fff;
+    cursor: pointer;
+    user-select: none;
+    padding: 10px;
 }
 
 /* Phaser 게임 캔버스를 담는 컨테이너 */

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -6,9 +6,17 @@ import { DOMEngine } from '../utils/DOMEngine.js';
  */
 export class TerritoryDOMEngine {
     constructor(scene, domEngine) {
+        this.scene = scene;
         this.domEngine = domEngine;
         this.container = document.getElementById('territory-container');
         this.grid = null;
+        this.tavernView = null; // 선술집 화면 컨테이너
+        this.hireModal = null;  // 용병 고용 모달
+        this.mercenaries = [
+            { name: '전사', image: 'assets/images/territory/warrior-hire.png' },
+            { name: '거너', image: 'assets/images/territory/gunner-hire.png' }
+        ];
+        this.currentMercenaryIndex = 0;
 
         this.createGrid();
         this.addBuilding(0, 0, 'tavern-icon', '[여관]');
@@ -18,20 +26,18 @@ export class TerritoryDOMEngine {
         this.grid = document.createElement('div');
         this.grid.id = 'territory-grid';
 
-        // surveyEngine의 값을 사용해 그리드 스타일을 설정
         const gridConfig = surveyEngine.territoryGrid;
         this.grid.style.gridTemplateColumns = `repeat(${gridConfig.cols}, 1fr)`;
         this.grid.style.gridTemplateRows = `repeat(${gridConfig.rows}, 1fr)`;
-        
+
         this.container.appendChild(this.grid);
     }
-    
+
     addBuilding(col, row, iconId, tooltipText) {
         const icon = document.createElement('div');
         icon.className = 'building-icon';
         icon.style.backgroundImage = `url(assets/images/territory/${iconId}.png)`;
-        
-        // CSS Grid의 위치 지정 (col, row 인덱스는 1부터 시작)
+
         icon.style.gridColumnStart = col + 1;
         icon.style.gridRowStart = row + 1;
 
@@ -45,12 +51,119 @@ export class TerritoryDOMEngine {
 
         icon.addEventListener('click', () => {
             console.log(`${tooltipText} 건물을 클릭했습니다.`);
+            if (iconId === 'tavern-icon') {
+                this.showTavernView();
+            }
         });
 
         this.grid.appendChild(icon);
     }
 
+    showTavernView() {
+        // 기존 그리드 숨기기
+        this.grid.style.display = 'none';
+
+        // 배경 이미지 변경
+        this.container.style.backgroundImage = `url(assets/images/territory/tavern-scene.png)`;
+
+        this.tavernView = document.createElement('div');
+        this.tavernView.id = 'tavern-view';
+        this.container.appendChild(this.tavernView);
+
+        const tavernGrid = document.createElement('div');
+        tavernGrid.id = 'tavern-grid';
+        this.tavernView.appendChild(tavernGrid);
+
+        const hireButton = document.createElement('div');
+        hireButton.className = 'tavern-button';
+        hireButton.style.backgroundImage = `url(assets/images/territory/hire-icon.png)`;
+        hireButton.addEventListener('click', () => {
+            this.showHireModal();
+        });
+        hireButton.addEventListener('mouseover', (event) => {
+            this.domEngine.showTooltip(event.clientX, event.clientY, '[용병 고용]');
+        });
+        hireButton.addEventListener('mouseout', () => {
+            this.domEngine.hideTooltip();
+        });
+
+        tavernGrid.appendChild(hireButton);
+    }
+
+    showHireModal() {
+        if (this.hireModal) return;
+
+        this.hireModal = document.createElement('div');
+        this.hireModal.id = 'hire-modal-overlay';
+
+        const modalContent = document.createElement('div');
+        modalContent.id = 'hire-modal-content';
+
+        const imageViewer = document.createElement('div');
+        imageViewer.id = 'hire-image-viewer';
+
+        const mercenaryImage = document.createElement('img');
+        mercenaryImage.id = 'mercenary-image';
+
+        const leftArrow = document.createElement('div');
+        leftArrow.className = 'hire-arrow';
+        leftArrow.innerText = '<';
+        leftArrow.onclick = () => this.changeMercenary(-1);
+
+        const rightArrow = document.createElement('div');
+        rightArrow.className = 'hire-arrow';
+        rightArrow.innerText = '>';
+        rightArrow.onclick = () => this.changeMercenary(1);
+
+        const closeButton = document.createElement('div');
+        closeButton.id = 'hire-modal-close';
+        closeButton.innerText = 'X';
+        closeButton.onclick = () => this.hideHireModal();
+
+        imageViewer.appendChild(leftArrow);
+        imageViewer.appendChild(mercenaryImage);
+        imageViewer.appendChild(rightArrow);
+
+        modalContent.appendChild(closeButton);
+        modalContent.appendChild(imageViewer);
+        this.hireModal.appendChild(modalContent);
+        this.container.appendChild(this.hireModal);
+
+        this.hireModal.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            this.changeMercenary(event.deltaY > 0 ? 1 : -1);
+        });
+
+        this.updateMercenaryImage();
+    }
+
+    hideHireModal() {
+        if (this.hireModal) {
+            this.hireModal.remove();
+            this.hireModal = null;
+        }
+    }
+
+    changeMercenary(direction) {
+        this.currentMercenaryIndex += direction;
+        if (this.currentMercenaryIndex >= this.mercenaries.length) {
+            this.currentMercenaryIndex = 0;
+        } else if (this.currentMercenaryIndex < 0) {
+            this.currentMercenaryIndex = this.mercenaries.length - 1;
+        }
+        this.updateMercenaryImage();
+    }
+
+    updateMercenaryImage() {
+        const mercenaryImage = document.getElementById('mercenary-image');
+        if (mercenaryImage) {
+            const newMercenary = this.mercenaries[this.currentMercenaryIndex];
+            mercenaryImage.src = newMercenary.image;
+            mercenaryImage.alt = newMercenary.name;
+        }
+    }
+
     destroy() {
-        this.container.innerHTML = ''; // 간단하게 내용만 비움
+        this.container.innerHTML = '';
     }
 }

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -57,6 +57,12 @@ export class Preloader extends Scene
 
         // 여관 아이콘 이미지를 로드합니다.
         this.load.image('tavern-icon', 'images/territory/tavern-icon.png');
+
+        // --- 추가된 애셋들 ---
+        this.load.image('tavern-scene', 'images/territory/tavern-scene.png');
+        this.load.image('hire-icon', 'images/territory/hire-icon.png');
+        this.load.image('warrior-hire', 'images/territory/warrior-hire.png');
+        this.load.image('gunner-hire', 'images/territory/gunner-hire.png');
     }
 
     create ()


### PR DESCRIPTION
## Summary
- preload new tavern related images
- implement tavern view and hire modal in `TerritoryDOMEngine`
- style tavern view and hire modal

## Testing
- `python3 -m http.server 8000 &`
- `curl -I http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687c78c52854832791687cc78a5f9a77