### PR TITLE
Add unit detail overlay and preload images

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -157,6 +157,12 @@ body {
     max-width: 400px;
     max-height: 600px;
     border-radius: 5px;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+#mercenary-image:hover {
+    transform: scale(1.02);
 }
 
 .hire-arrow {
@@ -171,4 +177,169 @@ body {
 #game-container {
     position: absolute;
     z-index: 1; 
+}
+
+/* --- 유닛 상세 정보창 스타일 --- */
+#unit-detail-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+    pointer-events: auto;
+}
+
+#unit-detail-pane {
+    width: 800px;
+    height: 600px;
+    background-color: #2c2a29;
+    border: 3px solid #1a1817;
+    border-radius: 8px;
+    box-shadow: 0 0 30px rgba(0,0,0,0.7);
+    color: #e0e0e0;
+    font-family: sans-serif;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+#unit-detail-close {
+    position: absolute;
+    top: 15px;
+    right: 20px;
+    font-size: 20px;
+    cursor: pointer;
+    color: #888;
+}
+#unit-detail-close:hover {
+    color: #fff;
+}
+
+.detail-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 24px;
+    font-weight: bold;
+    border-bottom: 2px solid #444;
+    padding-bottom: 10px;
+    margin-bottom: 15px;
+}
+.unit-name {
+    color: #fff;
+}
+.unit-level {
+    color: #f0e68c;
+}
+
+.detail-content {
+    display: flex;
+    flex-grow: 1;
+    gap: 20px;
+}
+
+.detail-section {
+    display: flex;
+    flex-direction: column;
+}
+.detail-section.left {
+    width: 40%;
+}
+.detail-section.right {
+    width: 60%;
+    display: flex;
+    gap: 15px;
+}
+
+.unit-portrait {
+    width: 100%;
+    height: 300px;
+    background-size: cover;
+    background-position: center top;
+    border-radius: 5px;
+    border: 2px solid #555;
+    margin-bottom: 15px;
+}
+
+.unit-description {
+    font-style: italic;
+    color: #aaa;
+    border: 1px dashed #555;
+    padding: 10px;
+    border-radius: 5px;
+    text-align: center;
+}
+
+.section-title {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-align: center;
+    background-color: #3a3837;
+    padding: 5px;
+    border-radius: 3px;
+}
+
+.stats-grid, .equipment-grid {
+    flex: 1;
+}
+
+.stat-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 8px;
+    background-color: rgba(0,0,0,0.2);
+    margin-bottom: 4px;
+    border-radius: 2px;
+}
+.stat-item span:last-child {
+    color: #fff;
+    font-weight: bold;
+}
+
+.equip-slot {
+    height: 50px;
+    background-color: rgba(0,0,0,0.3);
+    border: 1px solid #444;
+    margin-bottom: 8px;
+    border-radius: 4px;
+}
+
+.detail-footer {
+    display: flex;
+    border-top: 2px solid #444;
+    padding-top: 10px;
+    margin-top: 15px;
+    gap: 20px;
+}
+
+.unit-class {
+    width: 100px;
+}
+.class-icon {
+    width: 100%;
+    height: 60px;
+    background-color: rgba(0,0,0,0.3);
+    border: 1px solid #444;
+    border-radius: 4px;
+}
+
+.unit-skills {
+    flex-grow: 1;
+}
+.skill-grid {
+    display: flex;
+    gap: 10px;
+}
+.skill-slot {
+    flex: 1;
+    height: 60px;
+    background-color: rgba(0,0,0,0.3);
+    border: 1px solid #444;
+    border-radius: 4px;
 }

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -1,8 +1,10 @@
 import { surveyEngine } from '../utils/SurveyEngine.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
+// StatEngine을 불러옵니다.
+import { statEngine } from '../utils/StatEngine.js';
 
 /**
- * 영지 화면의 DOM 요소를 생성하고 관리하는 전용 엔진 (수정된 버전)
+ * 영지 화면의 DOM 요소를 생성하고 관리하는 전용 엔진
  */
 export class TerritoryDOMEngine {
     constructor(scene, domEngine) {
@@ -10,12 +12,36 @@ export class TerritoryDOMEngine {
         this.domEngine = domEngine;
         this.container = document.getElementById('territory-container');
         this.grid = null;
-        this.tavernView = null; // 선술집 화면 컨테이너
-        this.hireModal = null;  // 용병 고용 모달
-        this.mercenaries = [
-            { name: '전사', image: 'assets/images/territory/warrior-hire.png' },
-            { name: '거너', image: 'assets/images/territory/gunner-hire.png' }
-        ];
+        this.tavernView = null;
+        this.hireModal = null;
+        this.unitDetailView = null; // 유닛 상세 정보창 컨테이너
+
+        // --- 용병 기본 데이터 정의 ---
+        this.mercenaries = {
+            warrior: {
+                id: 'warrior',
+                name: '전사',
+                hireImage: 'assets/images/territory/warrior-hire.png',
+                uiImage: 'assets/images/territory/warrior-ui.png', // 상세 정보창용 이미지
+                description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
+                baseStats: {
+                    hp: 120, valor: 10, strength: 15, endurance: 12,
+                    agility: 8, intelligence: 5, wisdom: 5, luck: 7
+                }
+            },
+            gunner: {
+                id: 'gunner',
+                name: '거너',
+                hireImage: 'assets/images/territory/gunner-hire.png',
+                uiImage: 'assets/images/territory/gunner-ui.png', // 상세 정보창용 이미지
+                description: '"한 발, 한 발. 신중하게, 그리고 차갑게."',
+                baseStats: {
+                    hp: 80, valor: 5, strength: 7, endurance: 6,
+                    agility: 15, intelligence: 8, wisdom: 10, luck: 12
+                }
+            }
+        };
+        this.mercenaryList = Object.values(this.mercenaries);
         this.currentMercenaryIndex = 0;
 
         this.createGrid();
@@ -50,7 +76,6 @@ export class TerritoryDOMEngine {
         });
 
         icon.addEventListener('click', () => {
-            console.log(`${tooltipText} 건물을 클릭했습니다.`);
             if (iconId === 'tavern-icon') {
                 this.showTavernView();
             }
@@ -135,6 +160,12 @@ export class TerritoryDOMEngine {
         });
 
         this.updateMercenaryImage();
+
+        // --- 수정: 이미지 클릭 시 상세 정보창을 띄우도록 변경 ---
+        mercenaryImage.onclick = () => {
+            const currentMercenaryData = this.mercenaryList[this.currentMercenaryIndex];
+            this.showUnitDetails(currentMercenaryData);
+        };
     }
 
     hideHireModal() {
@@ -146,20 +177,118 @@ export class TerritoryDOMEngine {
 
     changeMercenary(direction) {
         this.currentMercenaryIndex += direction;
-        if (this.currentMercenaryIndex >= this.mercenaries.length) {
+
+        if (this.currentMercenaryIndex >= this.mercenaryList.length) {
             this.currentMercenaryIndex = 0;
         } else if (this.currentMercenaryIndex < 0) {
-            this.currentMercenaryIndex = this.mercenaries.length - 1;
+            this.currentMercenaryIndex = this.mercenaryList.length - 1;
         }
+
         this.updateMercenaryImage();
     }
 
     updateMercenaryImage() {
         const mercenaryImage = document.getElementById('mercenary-image');
         if (mercenaryImage) {
-            const newMercenary = this.mercenaries[this.currentMercenaryIndex];
-            mercenaryImage.src = newMercenary.image;
+            const newMercenary = this.mercenaryList[this.currentMercenaryIndex];
+            mercenaryImage.src = newMercenary.hireImage;
             mercenaryImage.alt = newMercenary.name;
+        }
+    }
+
+    /**
+     * 유닛 상세 정보 UI를 생성하고 표시합니다.
+     * @param {object} unitData - 표시할 유닛의 데이터 (this.mercenaries 객체 중 하나)
+     */
+    showUnitDetails(unitData) {
+        if (this.unitDetailView) this.unitDetailView.remove();
+
+        // 1. StatEngine을 사용하여 최종 스탯을 계산합니다.
+        const finalStats = statEngine.calculateStats(unitData, unitData.baseStats, []);
+
+        // 2. UI 레이아웃을 동적으로 생성합니다.
+        this.unitDetailView = document.createElement('div');
+        this.unitDetailView.id = 'unit-detail-overlay';
+        this.unitDetailView.onclick = (e) => {
+            if (e.target.id === 'unit-detail-overlay') {
+                this.hideUnitDetails();
+            }
+        };
+
+        const detailPane = document.createElement('div');
+        detailPane.id = 'unit-detail-pane';
+
+        detailPane.innerHTML += `
+            <div class="detail-header">
+                <span class="unit-name">no.001 ${unitData.name}</span>
+                <span class="unit-level">Lv. 1</span>
+            </div>
+            <div id="unit-detail-close" onclick="this.closest('#unit-detail-overlay').remove()">X</div>
+        `;
+
+        const detailContent = document.createElement('div');
+        detailContent.className = 'detail-content';
+
+        const leftSection = document.createElement('div');
+        leftSection.className = 'detail-section left';
+        leftSection.innerHTML = `
+            <div class="unit-portrait" style="background-image: url(${unitData.uiImage})"></div>
+            <div class="unit-description">"${unitData.description}"</div>
+        `;
+
+        const rightSection = document.createElement('div');
+        rightSection.className = 'detail-section right';
+        rightSection.innerHTML = `
+            <div class="stats-grid">
+                <div class="section-title">스탯</div>
+                <div class="stat-item"><span>HP</span><span>${finalStats.hp}</span></div>
+                <div class="stat-item"><span>용맹</span><span>${finalStats.valor}</span></div>
+                <div class="stat-item"><span>힘</span><span>${finalStats.strength}</span></div>
+                <div class="stat-item"><span>인내</span><span>${finalStats.endurance}</span></div>
+                <div class="stat-item"><span>민첩</span><span>${finalStats.agility}</span></div>
+                <div class="stat-item"><span>지능</span><span>${finalStats.intelligence}</span></div>
+                <div class="stat-item"><span>지혜</span><span>${finalStats.wisdom}</span></div>
+                <div class="stat-item"><span>행운</span><span>${finalStats.luck}</span></div>
+            </div>
+            <div class="equipment-grid">
+                <div class="section-title">장비</div>
+                <div class="equip-slot"></div>
+                <div class="equip-slot"></div>
+                <div class="equip-slot"></div>
+                <div class="equip-slot"></div>
+                <div class="equip-slot"></div>
+            </div>
+        `;
+
+        const detailFooter = document.createElement('div');
+        detailFooter.className = 'detail-footer';
+        detailFooter.innerHTML = `
+            <div class="unit-class">
+                <div class="section-title">병종</div>
+                <div class="class-icon"></div>
+            </div>
+            <div class="unit-skills">
+                <div class="section-title">스킬</div>
+                <div class="skill-grid">
+                    <div class="skill-slot"></div>
+                    <div class="skill-slot"></div>
+                    <div class="skill-slot"></div>
+                </div>
+            </div>
+        `;
+
+        detailContent.appendChild(leftSection);
+        detailContent.appendChild(rightSection);
+        detailPane.appendChild(detailContent);
+        detailPane.appendChild(detailFooter);
+        this.unitDetailView.appendChild(detailPane);
+        this.container.appendChild(this.unitDetailView);
+    }
+
+    hideUnitDetails() {
+        if (this.unitDetailView) {
+            this.unitDetailView.remove();
+            this.unitDetailView = null;
         }
     }
 

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -63,6 +63,8 @@ export class Preloader extends Scene
         this.load.image('hire-icon', 'images/territory/hire-icon.png');
         this.load.image('warrior-hire', 'images/territory/warrior-hire.png');
         this.load.image('gunner-hire', 'images/territory/gunner-hire.png');
+        this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
+        this.load.image('gunner-ui', 'images/territory/gunner-ui.png');
     }
 
     create ()


### PR DESCRIPTION
## Summary
- preload new UI portraits for mercenaries
- overhaul `TerritoryDOMEngine` to support unit detail display
- refine hire modal interaction
- style tweaks for hire modal and add new unit detail styles

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687c82cf09a083278a1da1600b136e08