### PR TITLE
Add MercenaryEngine and update hiring flow

### DIFF
--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -1,7 +1,8 @@
 import { surveyEngine } from '../utils/SurveyEngine.js';
 import { DOMEngine } from '../utils/DOMEngine.js';
-// StatEngine을 불러옵니다.
+// StatEngine과 함께 MercenaryEngine을 불러옵니다.
 import { statEngine } from '../utils/StatEngine.js';
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 
 /**
  * 영지 화면의 DOM 요소를 생성하고 관리하는 전용 엔진
@@ -161,10 +162,15 @@ export class TerritoryDOMEngine {
 
         this.updateMercenaryImage();
 
-        // --- 수정: 이미지 클릭 시 상세 정보창을 띄우도록 변경 ---
+        // 이미지를 클릭하면 MercenaryEngine을 통해 고용을 진행합니다.
         mercenaryImage.onclick = () => {
-            const currentMercenaryData = this.mercenaryList[this.currentMercenaryIndex];
-            this.showUnitDetails(currentMercenaryData);
+            const baseMercenaryData = this.mercenaryList[this.currentMercenaryIndex];
+            // 1. MercenaryEngine에 고용을 요청합니다.
+            const newInstance = mercenaryEngine.hireMercenary(baseMercenaryData);
+
+            // 2. 고용 창을 닫고, 반환된 새 인스턴스로 상세 정보창을 엽니다.
+            this.hideHireModal();
+            this.showUnitDetails(newInstance);
         };
     }
 
@@ -198,7 +204,7 @@ export class TerritoryDOMEngine {
 
     /**
      * 유닛 상세 정보 UI를 생성하고 표시합니다.
-     * @param {object} unitData - 표시할 유닛의 데이터 (this.mercenaries 객체 중 하나)
+     * @param {object} unitData - 표시할 유닛의 데이터 (고유 인스턴스)
      */
     showUnitDetails(unitData) {
         if (this.unitDetailView) this.unitDetailView.remove();

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -1,0 +1,58 @@
+import { statEngine } from './StatEngine.js';
+
+/**
+ * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
+ */
+class MercenaryEngine {
+    constructor() {
+        // --- 고용한 용병과 이름 목록, 고유 ID 관리 ---
+        this.hiredMercenaries = new Map(); // Map을 사용하여 고유 ID로 관리
+        this.mercenaryNames = ['크리스', '레온', '아이온', '가레스', '로릭', '이반', '오린', '바엘', '팰크', '스팅'];
+        this.nextUnitId = 1;
+    }
+
+    /**
+     * 특정 타입의 용병을 고용하고, 고유한 인스턴스를 생성하여 반환합니다.
+     * @param {object} baseMercenaryData - 고용할 용병의 기본 데이터 (전사, 거너 등)
+     * @returns {object} - 고유 ID와 이름, 최종 스탯이 포함된 새로운 용병 인스턴스
+     */
+    hireMercenary(baseMercenaryData) {
+        // 1. 랜덤 이름을 할당합니다.
+        const randomName = this.mercenaryNames[Math.floor(Math.random() * this.mercenaryNames.length)];
+        const uniqueId = this.nextUnitId++;
+
+        // 2. 고유한 ID와 이름을 가진 새 인스턴스를 생성합니다.
+        const newInstance = {
+            ...baseMercenaryData,
+            uniqueId: uniqueId,
+            instanceName: randomName,
+            level: 1,
+            exp: 0,
+            equippedItems: []
+        };
+
+        // 3. StatEngine을 통해 최종 스탯을 계산하여 인스턴스에 추가합니다.
+        newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
+
+        // 4. 생성된 인스턴스를 시스템(Map)에 저장합니다.
+        this.hiredMercenaries.set(uniqueId, newInstance);
+
+        console.log('새 용병 고용됨:', newInstance);
+        console.log('현재 고용된 용병 목록:', this.hiredMercenaries);
+
+        // 5. 완성된 새 인스턴스를 반환합니다.
+        return newInstance;
+    }
+
+    /**
+     * 고유 ID로 고용된 용병 정보를 가져옵니다.
+     * @param {number} uniqueId - 찾을 용병의 고유 ID
+     * @returns {object|undefined} - 찾은 용병의 인스턴스
+     */
+    getMercenaryById(uniqueId) {
+        return this.hiredMercenaries.get(uniqueId);
+    }
+}
+
+// 다른 파일에서 MercenaryEngine의 유일한 인스턴스를 가져다 쓸 수 있도록 export 합니다.
+export const mercenaryEngine = new MercenaryEngine();


### PR DESCRIPTION
## Summary
- introduce `MercenaryEngine` singleton to manage hiring and storage of mercenaries
- update `TerritoryDOMEngine` to use the new engine when hiring
- clicking a mercenary image now hires the unit and opens the detail view

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687c8c5dddc08327adc7ea9c9b9eddbe