### PR TITLE
Add enemy hire flow with BirthReport logs

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -343,3 +343,24 @@ body {
     border: 1px solid #444;
     border-radius: 4px;
 }
+
+/* --- 용병 고용 모달에 버튼 스타일 추가 --- */
+#hire-enemy-button {
+    width: 50%;
+    padding: 8px;
+    margin-top: 15px;
+    background-color: #7f1d1d;
+    color: #fecaca;
+    font-size: 14px;
+    text-align: center;
+    border: 1px solid #991b1b;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+#hire-enemy-button:hover {
+    background-color: #991b1b;
+    color: #fff;
+}
+

--- a/src/game/debug/BirthReportManager.js
+++ b/src/game/debug/BirthReportManager.js
@@ -1,0 +1,41 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+/**
+ * 새로 생성된 모든 유닛(아군, 적군)의 데이터를 콘솔에 기록하는 매니저
+ */
+class BirthReportManager {
+    constructor() {
+        this.name = 'BirthReport';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 새로운 유닛 인스턴스의 '출생 신고' 로그를 콘솔에 그룹화하여 출력합니다.
+     * @param {object} unitInstance - 생성된 유닛의 전체 데이터
+     * @param {string} unitType - 유닛의 타입 ('아군' 또는 '적군')
+     */
+    logNewUnit(unitInstance, unitType) {
+        const typeColor = unitType === '아군' ? '#3b82f6' : '#ef4444';
+        const typeName = `[${unitType}]`;
+
+        console.groupCollapsed(
+            `%c[${this.name}]%c ${typeName}`,
+            `color: #a855f7; font-weight: bold;`,
+            `color: ${typeColor}; font-weight: bold;`,
+            `${unitInstance.instanceName} (ID: ${unitInstance.uniqueId}) 인스턴스 생성됨`
+        );
+
+        debugLogEngine.log(this.name, '--- 기본 정보 ---');
+        debugLogEngine.log(this.name, `고유 ID: ${unitInstance.uniqueId}`);
+        debugLogEngine.log(this.name, `이름: ${unitInstance.instanceName}`);
+        debugLogEngine.log(this.name, `클래스: ${unitInstance.name}`);
+        debugLogEngine.log(this.name, `레벨: ${unitInstance.level}`);
+
+        console.groupCollapsed(`%c[${this.name}] 최종 스탯 정보`, `color: #a855f7; font-weight: bold;`);
+        console.table(unitInstance.finalStats);
+        console.groupEnd();
+        console.groupEnd();
+    }
+}
+
+export const birthReportManager = new BirthReportManager();

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -1,27 +1,28 @@
 import { statEngine } from './StatEngine.js';
+import { birthReportManager } from '../debug/BirthReportManager.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
  */
 class MercenaryEngine {
     constructor() {
-        // --- 고용한 용병과 이름 목록, 고유 ID 관리 ---
-        this.hiredMercenaries = new Map(); // Map을 사용하여 고유 ID로 관리
+        this.alliedMercenaries = new Map();
+        this.enemyMercenaries = new Map();
+
         this.mercenaryNames = ['크리스', '레온', '아이온', '가레스', '로릭', '이반', '오린', '바엘', '팰크', '스팅'];
         this.nextUnitId = 1;
     }
 
     /**
      * 특정 타입의 용병을 고용하고, 고유한 인스턴스를 생성하여 반환합니다.
-     * @param {object} baseMercenaryData - 고용할 용병의 기본 데이터 (전사, 거너 등)
-     * @returns {object} - 고유 ID와 이름, 최종 스탯이 포함된 새로운 용병 인스턴스
+     * @param {object} baseMercenaryData - 고용할 용병의 기본 데이터
+     * @param {string} type - 생성할 유닛의 타입 ('ally' 또는 'enemy')
+     * @returns {object} - 새로운 용병 인스턴스
      */
-    hireMercenary(baseMercenaryData) {
-        // 1. 랜덤 이름을 할당합니다.
+    hireMercenary(baseMercenaryData, type = 'ally') {
         const randomName = this.mercenaryNames[Math.floor(Math.random() * this.mercenaryNames.length)];
         const uniqueId = this.nextUnitId++;
 
-        // 2. 고유한 ID와 이름을 가진 새 인스턴스를 생성합니다.
         const newInstance = {
             ...baseMercenaryData,
             uniqueId: uniqueId,
@@ -30,29 +31,23 @@ class MercenaryEngine {
             exp: 0,
             equippedItems: []
         };
-
-        // 3. StatEngine을 통해 최종 스탯을 계산하여 인스턴스에 추가합니다.
+        
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
-
-        // 4. 생성된 인스턴스를 시스템(Map)에 저장합니다.
-        this.hiredMercenaries.set(uniqueId, newInstance);
-
-        console.log('새 용병 고용됨:', newInstance);
-        console.log('현재 고용된 용병 목록:', this.hiredMercenaries);
-
-        // 5. 완성된 새 인스턴스를 반환합니다.
+        
+        if (type === 'ally') {
+            this.alliedMercenaries.set(uniqueId, newInstance);
+            birthReportManager.logNewUnit(newInstance, '아군');
+        } else {
+            this.enemyMercenaries.set(uniqueId, newInstance);
+            birthReportManager.logNewUnit(newInstance, '적군');
+        }
+        
         return newInstance;
     }
 
-    /**
-     * 고유 ID로 고용된 용병 정보를 가져옵니다.
-     * @param {number} uniqueId - 찾을 용병의 고유 ID
-     * @returns {object|undefined} - 찾은 용병의 인스턴스
-     */
-    getMercenaryById(uniqueId) {
-        return this.hiredMercenaries.get(uniqueId);
+    getMercenaryById(uniqueId, type = 'ally') {
+        return type === 'ally' ? this.alliedMercenaries.get(uniqueId) : this.enemyMercenaries.get(uniqueId);
     }
 }
 
-// 다른 파일에서 MercenaryEngine의 유일한 인스턴스를 가져다 쓸 수 있도록 export 합니다.
 export const mercenaryEngine = new MercenaryEngine();


### PR DESCRIPTION
## Summary
- add BirthReportManager for logging creation of units
- extend MercenaryEngine to keep allied and enemy units and notify the BirthReportManager
- update TerritoryDOMEngine to allow hiring enemy units and wire new buttons
- style enemy hire button

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687c8de067748327b23cc1e33b7c5a6e