### PR TITLE
Add Party management feature

### DIFF
--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -45,6 +45,8 @@ export class TerritoryDOMEngine {
 
         this.createGrid();
         this.addBuilding(0, 0, 'tavern-icon', '[여관]');
+        // --- 용병 관리 버튼 추가 ---
+        this.addPartyManagementButton(1, 0);
     }
 
     createGrid() {
@@ -81,6 +83,22 @@ export class TerritoryDOMEngine {
         });
 
         this.grid.appendChild(icon);
+    }
+
+    // --- 새로운 버튼 추가 메소드 ---
+    addPartyManagementButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        button.style.backgroundImage = `url(assets/images/territory/party-icon.png)`;
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[용병 관리]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            console.log('용병 관리 버튼 클릭');
+            this.scene.scene.start('PartyScene');
+        });
+        this.grid.appendChild(button);
     }
 
     showTavernView() {

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -1,6 +1,13 @@
 // Vite 없이 실행할 수 있도록 phaser ESM을 직접 참조합니다.
 // Phaser 모듈을 CDN에서 가져옵니다.
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { Preloader } from './Preloader.js';
+import { TerritoryScene } from './TerritoryScene.js';
+import { MainMenu } from './MainMenu.js';
+import { MainGame } from './Game.js';
+import { GameOver } from './GameOver.js';
+// --- PartyScene import 추가 ---
+import { PartyScene } from './PartyScene.js';
 
 export class Boot extends Scene
 {
@@ -19,6 +26,14 @@ export class Boot extends Scene
 
     create ()
     {
+        this.scene.add('Preloader', Preloader);
+        this.scene.add('TerritoryScene', TerritoryScene);
+        this.scene.add('MainMenu', MainMenu);
+        this.scene.add('MainGame', MainGame);
+        this.scene.add('GameOver', GameOver);
+        // --- PartyScene 추가 ---
+        this.scene.add('PartyScene', PartyScene);
+
         this.scene.start('Preloader');
     }
 }

--- a/src/game/scenes/PartyScene.js
+++ b/src/game/scenes/PartyScene.js
@@ -1,0 +1,98 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+
+export class PartyScene extends Scene {
+    constructor() {
+        super('PartyScene');
+        this.partyGridContainer = null;
+        this.unitDetailContainer = null;
+        this.partyMemberSprites = [];
+        this.currentSelectedUnit = null;
+    }
+
+    preload() {
+        this.load.image('party-scene-bg', 'assets/images/territory/party-scene.png');
+        this.load.image('warrior-small', 'assets/images/unit/warrior.png');
+        this.load.image('gunner-small', 'assets/images/unit/gunner.png');
+    }
+
+    create() {
+        // 배경 이미지 추가
+        this.add.image(this.cameras.main.centerX, this.cameras.main.centerY, 'party-scene-bg');
+
+        // 파티 그리드 컨테이너 생성
+        this.partyGridContainer = this.add.container(this.cameras.main.centerX, 100);
+        this.createPartyGrid();
+
+        // 유닛 상세 정보 컨테이너 생성 (처음에는 비어있음)
+        this.unitDetailContainer = this.add.container(this.cameras.main.centerX, 400);
+
+        // 뒤로 가기 버튼 (임시)
+        const backButton = this.add.text(20, 20, '영지로 돌아가기', { fontSize: '20px', fill: '#fff', backgroundColor: '#000' })
+            .setInteractive()
+            .on('pointerdown', () => this.scene.start('TerritoryScene'));
+    }
+
+    createPartyGrid() {
+        const partyMembers = mercenaryEngine.getPartyMembers();
+        const allMercenaries = mercenaryEngine.getAllAlliedMercenaries();
+        const gridSize = 12;
+        const cellWidth = 50;
+        const cellHeight = 50;
+        const spacing = 10;
+        const startX = -(gridSize * (cellWidth + spacing) / 2) + cellWidth / 2;
+
+        for (let i = 0; i < gridSize; i++) {
+            const x = startX + i * (cellWidth + spacing);
+            const y = 0;
+
+            const cell = this.add.rectangle(x, y, cellWidth, cellHeight, 0x333333).setOrigin(0.5);
+            this.partyGridContainer.add(cell);
+
+            if (partyMembers.length > i) {
+                const unitId = partyMembers [i];
+                const unitData = allMercenaries.find(merc => merc.uniqueId === unitId);
+                if (unitData) {
+                    let spriteKey = '';
+                    if (unitData.id === 'warrior') {
+                        spriteKey = 'warrior-small';
+                    } else if (unitData.id === 'gunner') {
+                        spriteKey = 'gunner-small';
+                    }
+
+                    if (spriteKey) {
+                        const sprite = this.add.image(x, y, spriteKey).setOrigin(0.5).setScale(0.8).setInteractive();
+                        sprite.unitId = unitId;
+                        sprite.on('pointerdown', () => this.showUnitDetails(unitId));
+                        this.partyMemberSprites.push(sprite);
+                        this.partyGridContainer.add(sprite);
+                    }
+                }
+            }
+        }
+    }
+
+    showUnitDetails(unitId) {
+        if (this.unitDetailContainer) {
+            this.unitDetailContainer.destroy(true);
+        }
+        this.unitDetailContainer = this.add.container(this.cameras.main.centerX, 500);
+        const unitData = mercenaryEngine.getMercenaryById(unitId);
+
+        if (unitData) {
+            const detailsText = this.add.text(0, 0, `이름: ${unitData.instanceName}\n클래스: ${unitData.name}\n레벨: ${unitData.level}\nHP: ${unitData.finalStats.hp}\n힘: ${unitData.finalStats.strength}\n민첩: ${unitData.finalStats.agility}`, {
+                fontSize: '16px',
+                fill: '#fff',
+                align: 'center',
+                backgroundColor: 'rgba(0,0,0,0.7)',
+                padding: { x: 15, y: 10 },
+                borderRadius: 5
+            }).setOrigin(0.5);
+            this.unitDetailContainer.add(detailsText);
+        } else {
+            const errorText = this.add.text(0, 0, '선택한 용병의 정보를 찾을 수 없습니다.', { fontSize: '16px', fill: '#f00' }).setOrigin(0.5);
+            this.unitDetailContainer.add(errorText);
+        }
+        this.currentSelectedUnit = unitId;
+    }
+}

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -1,5 +1,7 @@
 import { statEngine } from './StatEngine.js';
 import { birthReportManager } from '../debug/BirthReportManager.js';
+// PartyEngine을 불러옵니다.
+import { partyEngine } from './PartyEngine.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -33,10 +35,12 @@ class MercenaryEngine {
         };
         
         newInstance.finalStats = statEngine.calculateStats(newInstance, newInstance.baseStats, newInstance.equippedItems);
-        
+
         if (type === 'ally') {
             this.alliedMercenaries.set(uniqueId, newInstance);
             birthReportManager.logNewUnit(newInstance, '아군');
+            // --- 파티에 추가 ---
+            partyEngine.addPartyMember(uniqueId);
         } else {
             this.enemyMercenaries.set(uniqueId, newInstance);
             birthReportManager.logNewUnit(newInstance, '적군');
@@ -47,6 +51,14 @@ class MercenaryEngine {
 
     getMercenaryById(uniqueId, type = 'ally') {
         return type === 'ally' ? this.alliedMercenaries.get(uniqueId) : this.enemyMercenaries.get(uniqueId);
+    }
+
+    getAllAlliedMercenaries() {
+        return Array.from(this.alliedMercenaries.values());
+    }
+
+    getPartyMembers() {
+        return partyEngine.getPartyMembers();
     }
 }
 

--- a/src/game/utils/PartyEngine.js
+++ b/src/game/utils/PartyEngine.js
@@ -1,0 +1,44 @@
+/**
+ * 플레이어의 파티를 관리하는 엔진 (싱글턴)
+ */
+class PartyEngine {
+    constructor() {
+        this.partyMembers = []; // 고용된 아군 용병의 ID를 저장하는 배열 (최대 12명)
+        this.maxPartySize = 12;
+    }
+
+    /**
+     * 용병을 파티에 추가합니다.
+     * @param {number} unitId - 추가할 용병의 고유 ID
+     * @returns {boolean} - 파티 추가 성공 여부 (파티가 가득 찼으면 false)
+     */
+    addPartyMember(unitId) {
+        if (this.partyMembers.length < this.maxPartySize) {
+            this.partyMembers.push(unitId);
+            console.log(`용병 (ID: ${unitId})이 파티에 합류했습니다. 현재 파티:`, this.partyMembers);
+            return true;
+        } else {
+            console.warn('파티가 가득 찼습니다!');
+            return false;
+        }
+    }
+
+    /**
+     * 용병을 파티에서 제거합니다. (현재는 미구현)
+     * @param {number} unitId - 제거할 용병의 고유 ID
+     */
+    removePartyMember(unitId) {
+        this.partyMembers = this.partyMembers.filter(id => id !== unitId);
+        console.log(`용병 (ID: ${unitId})이 파티에서 떠났습니다. 현재 파티:`, this.partyMembers);
+    }
+
+    /**
+     * 현재 파티에 있는 모든 용병의 ID를 반환합니다.
+     * @returns {Array<number>} - 파티 멤버의 ID 배열
+     */
+    getPartyMembers() {
+        return [...this.partyMembers]; // 복사본을 반환하여 외부에서 직접 수정하는 것을 방지
+    }
+}
+
+export const partyEngine = new PartyEngine();


### PR DESCRIPTION
## Summary
- implement PartyEngine to manage mercenary party
- update MercenaryEngine to interface with PartyEngine
- add party management button on Territory UI
- create PartyScene for viewing party members
- register PartyScene in Boot scene

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687ca3dd894483278f04897b29997769