### PR TITLE
Fix party scene transition

### DIFF
--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -316,5 +316,6 @@ export class TerritoryDOMEngine {
 
     destroy() {
         this.container.innerHTML = '';
+        this.container.style.display = 'none';
     }
 }

--- a/src/game/scenes/TerritoryScene.js
+++ b/src/game/scenes/TerritoryScene.js
@@ -11,6 +11,11 @@ export class TerritoryScene extends Scene {
     }
 
     create() {
+        // 파티 관리 씬에서 돌아올 때 가려졌을 수 있는 영지 컨테이너를 다시 표시합니다.
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'block';
+        }
         // 중요: 이제 이 씬은 비어있습니다.
         // 모든 시각적 요소는 DOM 엔진들이 담당합니다.
         


### PR DESCRIPTION
## Summary
- hide the territory DOM container when the scene shuts down
- ensure the territory container becomes visible again when returning to the territory scene

## Testing
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687ca8541fdc8327874834d702b05961