### PR TITLE
Add back button to tavern view

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -86,6 +86,18 @@ body {
     align-items: center;
 }
 
+#tavern-back-button {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    padding: 6px 12px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border: 1px solid #fff;
+    border-radius: 4px;
+    color: #fff;
+    cursor: pointer;
+}
+
 #tavern-grid {
     /* position, top, left, transform 속성 제거 */
     width: 60%; /* 너비 조정 */

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -110,6 +110,14 @@ export class TerritoryDOMEngine {
         this.tavernView.id = 'tavern-view';
         this.container.appendChild(this.tavernView);
 
+        const backButton = document.createElement('div');
+        backButton.id = 'tavern-back-button';
+        backButton.innerText = '← 영지로 돌아가기';
+        backButton.addEventListener('click', () => {
+            this.hideTavernView();
+        });
+        this.tavernView.appendChild(backButton);
+
         const tavernGrid = document.createElement('div');
         tavernGrid.id = 'tavern-grid';
         this.tavernView.appendChild(tavernGrid);
@@ -201,6 +209,15 @@ export class TerritoryDOMEngine {
             this.hireModal.remove();
             this.hireModal = null;
         }
+    }
+
+    hideTavernView() {
+        if (this.tavernView) {
+            this.tavernView.remove();
+            this.tavernView = null;
+        }
+        this.container.style.backgroundImage = `url(assets/images/territory/city-1.png)`;
+        this.grid.style.display = 'grid';
     }
 
     changeMercenary(direction) {


### PR DESCRIPTION
## Summary
- add DOM-based back button for tavern view
- support returning to territory screen with hideTavernView
- style new back button

## Testing
- `python3 -m http.server 8000`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687cab7b7170832789dcc1a8939e36d7