### PR TITLE
Fix portrait and logo scaling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -271,7 +271,9 @@ body {
 .unit-portrait {
     width: 100%;
     height: 300px;
-    background-size: cover;
+    /* 이미지가 잘리지 않도록 contain 사용 */
+    background-size: contain;
+    background-repeat: no-repeat;
     background-position: center top;
     border-radius: 5px;
     border: 2px solid #555;

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -15,7 +15,13 @@ export class Preloader extends Scene
 
         // 화면 중앙에 로고를 추가합니다.
         // 이 로고는 아래 preload 함수에서 로드될 것입니다.
-        this.add.image(512, 300, 'logo');
+        const logo = this.add.image(512, 300, 'logo');
+        const logoTexture = this.textures.get('logo');
+        // 로고의 원본 너비를 이용해 스케일을 조절하여 항상 400px 폭으로 보이게 합니다.
+        if (logoTexture && logoTexture.source[0].width > 0) {
+            const scale = 400 / logoTexture.source[0].width;
+            logo.setScale(scale);
+        }
 
         // --- 로딩 진행률 표시줄 ---
 


### PR DESCRIPTION
## Summary
- ensure `.unit-portrait` images use `background-size: contain` and no-repeat
- scale logo width to 400px in Preloader scene

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687cb05554508327b6cdc48a7e3c6c30