### PR TITLE
Add image scaling manager and cleanup

### DIFF
--- a/src/game/debug/DebugImageLogManager.js
+++ b/src/game/debug/DebugImageLogManager.js
@@ -1,0 +1,32 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugImageLogManager {
+    constructor() {
+        this.name = 'DebugImage';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 이미지 리사이즈 정보를 콘솔에 그룹화하여 출력합니다.
+     * @param {string} key - 이미지의 텍스처 키
+     * @param {object} originalSize - {width, height} 원본 크기
+     * @param {object} targetInfo - {type, targetSize, dimension} 목표 정보
+     * @param {number} scale - 최종 적용된 스케일 값
+     */
+    logResize(key, originalSize, targetInfo, scale) {
+        console.groupCollapsed(
+            `%c[${this.name}]`,
+            `color: #f59e0b; font-weight: bold;`,
+            `'${key}' 이미지 크기 조절됨`
+        );
+
+        debugLogEngine.log(this.name, `원본 크기: ${originalSize.width}x${originalSize.height}`);
+        debugLogEngine.log(this.name, `목표 유형: ${targetInfo.type}`);
+        debugLogEngine.log(this.name, `목표 기준: ${targetInfo.dimension}을(를) ${targetInfo.targetSize}px로 설정`);
+        debugLogEngine.log(this.name, `계산된 스케일: ${scale.toFixed(4)}`);
+
+        console.groupEnd();
+    }
+}
+
+export const debugImageLogManager = new DebugImageLogManager();

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,7 +1,5 @@
 import { Scene } from "https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js";
 import { cameraEngine } from '../utils/CameraEngine.js';
-import { debugLogEngine } from '../utils/DebugLogEngine.js';
-import { debugCombatLogManager } from '../debug/DebugCombatLogManager.js';
 import { debugCameraLogManager } from '../debug/DebugCameraLogManager.js';
 
 export class Game extends Scene {
@@ -16,50 +14,8 @@ export class Game extends Scene {
         // --- 1. 카메라 엔진에 현재 씬 등록 ---
         // 이 과정이 있어야 엔진이 어떤 카메라를 제어할지 알 수 있습니다.
         cameraEngine.registerScene(this);
+        
         // 게임 시작 시, 카메라의 초기 상태를 로그로 남깁니다.
         debugCameraLogManager.logInitialState(this.cameras.main, this.sys.game.config);
-
-        // --- 2. 테스트용 유닛(스프라이트) 생성 ---
-        const warrior = this.add.sprite(250, 384, 'warrior').setInteractive();
-        warrior.name = '전사'; // 디버그 로그에 표시될 이름
-
-        const zombie = this.add.sprite(774, 384, 'zombie'); // 아직 로드하지 않았으니 이미지가 깨질 수 있습니다.
-        zombie.name = '좀비';
-        // warrior 이미지를 임시로 사용합니다. Preloader.js에 'zombie'를 추가하면 정상적으로 보입니다.
-        if (!this.textures.exists('zombie')) {
-            zombie.setTexture('warrior').setTint(0x88ff88);
-        }
-
-        // 전투 로그 매니저 데모용 간단한 스탯 객체
-        const warriorStats = { name: '용맹한 전사', atk: 25, def: 10 };
-        const zombieStats = { name: '비틀거리는 좀비', atk: 15, def: 5 };
-        debugCombatLogManager.logAttackCalculation(warriorStats, zombieStats, 25, 20);
-        debugCombatLogManager.logAttackCalculation(zombieStats, warriorStats, 15, 5);
-
-        // --- 3. 카메라 연출 실행 및 이벤트 연결 ---
-        this.add.text(512, 50, '전사를 클릭하면 전투 연출이 시작됩니다.', {
-            fontFamily: 'Arial Black', fontSize: 24, color: '#ffffff',
-            stroke: '#000000', strokeThickness: 6
-        }).setOrigin(0.5);
-
-        warrior.on('pointerdown', async () => {
-            debugLogEngine.log('Game', '전투 시퀀스 시작!');
-            
-            // async/await를 사용하여 카메라 연출을 순서대로 실행합니다.
-            // 1. 전사 클로즈업
-            await cameraEngine.closeupOn(warrior, 1.5, 500);
-            
-            // 2. 공격하는 것처럼 화면 흔들기
-            await cameraEngine.shake(0.02, 300);
-            
-            // 3. 좀비에게 피격 이펙트 (간단히 색상 변경으로 표현)
-            zombie.setTint(0xff0000);
-            this.time.delayedCall(100, () => zombie.clearTint().setTint(0x88ff88));
-            
-            // 4. 원래 시점으로 복귀
-            await cameraEngine.reset(500);
-
-            debugLogEngine.log('Game', '전투 시퀀스 종료!');
-        });
     }
 }

--- a/src/game/scenes/PartyScene.js
+++ b/src/game/scenes/PartyScene.js
@@ -1,5 +1,6 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+import { imageSizeManager } from '../utils/ImageSizeManager.js';
 
 export class PartyScene extends Scene {
     constructor() {
@@ -66,9 +67,8 @@ export class PartyScene extends Scene {
                     if (this.textures.exists(spriteKey)) {
                         const sprite = this.add.image(x, y, spriteKey).setOrigin(0.5).setInteractive();
 
-                        // 타일 크기에 맞도록 동적으로 스케일을 계산합니다.
-                        const texture = this.textures.get(spriteKey);
-                        const scale = cellWidth / texture.source[0].width;
+                        // 타일 크기에 맞도록 ImageSizeManager를 사용해 스케일을 계산합니다.
+                        const scale = imageSizeManager.getScale('ICON_IN_PARTY', sprite.texture, 'width');
                         sprite.setScale(scale);
 
                         sprite.unitId = unitId;

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,5 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { imageSizeManager } from '../utils/ImageSizeManager.js';
 
 export class Preloader extends Scene
 {
@@ -13,15 +14,15 @@ export class Preloader extends Scene
         // 이 이미지는 Boot.js에서 미리 로드되었습니다.
         this.add.image(512, 384, 'background');
 
-        // 화면 중앙에 로고를 추가합니다.
-        // 이 로고는 아래 preload 함수에서 로드될 것입니다.
-        const logo = this.add.image(512, 300, 'logo');
-        const logoTexture = this.textures.get('logo');
-        // 로고의 원본 너비를 이용해 스케일을 조절하여 항상 400px 폭으로 보이게 합니다.
-        if (logoTexture && logoTexture.source[0].width > 0) {
-            const scale = 400 / logoTexture.source[0].width;
-            logo.setScale(scale);
-        }
+        // 모든 리소스 로드 완료 후 로고를 중앙에 표시하고 스케일을 조정합니다.
+        this.load.on('complete', () => {
+            const logo = this.add.image(512, 300, 'logo');
+            const logoTexture = this.textures.get('logo');
+            if (logoTexture.key !== '__MISSING') {
+                const scale = imageSizeManager.getScale('LOGO', logoTexture, 'width');
+                logo.setScale(scale);
+            }
+        });
 
         // --- 로딩 진행률 표시줄 ---
 

--- a/src/game/utils/ImageSizeManager.js
+++ b/src/game/utils/ImageSizeManager.js
@@ -1,0 +1,50 @@
+import { debugImageLogManager } from '../debug/DebugImageLogManager.js';
+
+/**
+ * 게임 내 모든 이미지의 목표 크기를 정의하고,
+ * 원본 크기에 따른 적절한 스케일 값을 계산하는 중앙 관리 매니저.
+ */
+class ImageSizeManager {
+    constructor() {
+        // 이미지 종류별 목표 크기(너비 기준)를 정의합니다.
+        // 단위는 픽셀(px)입니다.
+        this.targetSizes = {
+            LOGO: 400,          // 메인 로고 너비
+            ICON_IN_PARTY: 50   // 용병 관리 그리드 아이콘 너비
+        };
+    }
+
+    /**
+     * 이미지 종류와 원본 텍스처를 받아 적절한 스케일 값을 계산하여 반환합니다.
+     * @param {string} type - 'LOGO', 'ICON_IN_PARTY' 등
+     * @param {Phaser.Textures.Texture} texture - Phaser의 텍스처 객체
+     * @param {string} dimension - 크기 기준 ('width' 또는 'height')
+     * @returns {number} - 계산된 스케일 값
+     */
+    getScale(type, texture, dimension = 'width') {
+        const targetSize = this.targetSizes[type];
+        if (!targetSize) {
+            console.warn(`ImageSizeManager: '${type}'에 대한 목표 크기가 정의되지 않았습니다.`);
+            return 1;
+        }
+
+        const originalSize = texture.source[0][dimension];
+        if (originalSize === 0) {
+            return 1; // 텍스처가 아직 로드되지 않았을 수 있습니다.
+        }
+
+        const scale = targetSize / originalSize;
+
+        // 디버그 로그를 남깁니다.
+        debugImageLogManager.logResize(
+            texture.key,
+            { width: texture.source[0].width, height: texture.source[0].height },
+            { type, targetSize, dimension },
+            scale
+        );
+
+        return scale;
+    }
+}
+
+export const imageSizeManager = new ImageSizeManager();


### PR DESCRIPTION
## Summary
- centralize image scaling logic via `ImageSizeManager`
- log resize operations with `DebugImageLogManager`
- apply global scaling in Preloader and PartyScene
- simplify Game scene setup and camera logging
- remove unused debug image imports

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`
- `npm run build-nolog`


------
https://chatgpt.com/codex/tasks/task_e_687cb32189988327b5d7772b92a191b9