### PR TITLE
Implement dungeon screen and battle engine foundation

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -12,6 +12,7 @@
     <div id="app">
         <div id="game-container"></div>
         <div id="territory-container"></div>
+        <div id="dungeon-container"></div>
         <div id="party-container"></div>
         <div id="ui-container"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <div id="app">
         <div id="game-container"></div>
         <div id="territory-container"></div>
+        <div id="dungeon-container"></div>
         <div id="party-container"></div>
         <div id="ui-container"></div>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -463,3 +463,64 @@ body {
     color: #fff;
 }
 
+
+/* --- 출정 화면 DOM 스타일 --- */
+#dungeon-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    pointer-events: none;
+    background-size: cover;
+    background-position: center;
+    display: none;
+}
+
+#dungeon-grid {
+    position: absolute;
+    top: 10%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 30%;
+    height: 80%;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(10, 1fr);
+    gap: 10px;
+    pointer-events: auto;
+}
+
+.dungeon-tile {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    background-size: cover;
+    background-position: center;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.dungeon-label {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    background-color: rgba(0,0,0,0.6);
+    color: #fff;
+    font-size: 14px;
+    text-align: center;
+}
+
+#dungeon-back-button {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    padding: 6px 12px;
+    background-color: rgba(0,0,0,0.7);
+    border: 1px solid #fff;
+    border-radius: 4px;
+    color: #fff;
+    cursor: pointer;
+    pointer-events: auto;
+}

--- a/src/game/dom/DungeonDOMEngine.js
+++ b/src/game/dom/DungeonDOMEngine.js
@@ -1,0 +1,48 @@
+import { DOMEngine } from '../utils/DOMEngine.js';
+
+/**
+ * 출정 화면의 DOM 요소를 생성하고 관리하는 엔진
+ */
+export class DungeonDOMEngine {
+    constructor(scene, domEngine) {
+        this.scene = scene;
+        this.domEngine = domEngine;
+        this.container = document.getElementById('dungeon-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'dungeon-container';
+            document.getElementById('app').appendChild(this.container);
+        }
+        this.grid = null;
+        this.createView();
+    }
+
+    createView() {
+        this.container.style.display = 'block';
+        this.container.style.backgroundImage = 'url(assets/images/territory/dungeon-scene.png)';
+
+        const grid = document.createElement('div');
+        grid.id = 'dungeon-grid';
+        this.container.appendChild(grid);
+        this.grid = grid;
+
+        // 첫 번째 타일 예시
+        const tile = document.createElement('div');
+        tile.className = 'dungeon-tile';
+        tile.style.backgroundImage = 'url(assets/images/territory/cursed-forest.png)';
+        tile.addEventListener('click', () => {
+            console.log('저주받은 숲 선택');
+        });
+
+        const label = document.createElement('div');
+        label.className = 'dungeon-label';
+        label.innerText = '[저주받은 숲]';
+        tile.appendChild(label);
+        grid.appendChild(tile);
+    }
+
+    destroy() {
+        this.container.innerHTML = '';
+        this.container.style.display = 'none';
+    }
+}

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -47,6 +47,8 @@ export class TerritoryDOMEngine {
         this.addBuilding(0, 0, 'tavern-icon', '[여관]');
         // --- 용병 관리 버튼 추가 ---
         this.addPartyManagementButton(1, 0);
+        // --- 출정 버튼 추가 ---
+        this.addExpeditionButton(2, 0);
     }
 
     createGrid() {
@@ -101,6 +103,21 @@ export class TerritoryDOMEngine {
             this.container.style.display = 'none';
 
             this.scene.scene.start('PartyScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    addExpeditionButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        button.style.backgroundImage = `url(assets/images/territory/dungeon-icon.png)`;
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[출정]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            this.scene.scene.start('DungeonScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -9,6 +9,7 @@ import { Game as MainGame } from './Game.js';
 import { GameOver } from './GameOver.js';
 // --- PartyScene import 추가 ---
 import { PartyScene } from './PartyScene.js';
+import { DungeonScene } from './DungeonScene.js';
 
 export class Boot extends Scene
 {
@@ -34,6 +35,7 @@ export class Boot extends Scene
         this.scene.add('GameOver', GameOver);
         // --- PartyScene 추가 ---
         this.scene.add('PartyScene', PartyScene);
+        this.scene.add('DungeonScene', DungeonScene);
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/DungeonScene.js
+++ b/src/game/scenes/DungeonScene.js
@@ -1,0 +1,31 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { DOMEngine } from '../utils/DOMEngine.js';
+import { DungeonDOMEngine } from '../dom/DungeonDOMEngine.js';
+
+export class DungeonScene extends Scene {
+    constructor() {
+        super('DungeonScene');
+        this.dungeonDomEngine = null;
+    }
+
+    create() {
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'none';
+        }
+        const domEngine = new DOMEngine(this);
+        this.dungeonDomEngine = new DungeonDOMEngine(this, domEngine);
+
+        const backButton = document.createElement('div');
+        backButton.id = 'dungeon-back-button';
+        backButton.innerText = '← 영지로 돌아가기';
+        backButton.addEventListener('click', () => {
+            this.scene.start('TerritoryScene');
+        });
+        document.getElementById('dungeon-container').appendChild(backButton);
+
+        this.events.on('shutdown', () => {
+            this.dungeonDomEngine.destroy();
+        });
+    }
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -72,6 +72,9 @@ export class Preloader extends Scene
         this.load.image('gunner-hire', 'images/territory/gunner-hire.png');
         this.load.image('warrior-ui', 'images/territory/warrior-ui.png');
         this.load.image('gunner-ui', 'images/territory/gunner-ui.png');
+        this.load.image('dungeon-icon', 'images/territory/dungeon-icon.png');
+        this.load.image('dungeon-scene', 'images/territory/dungeon-scene.png');
+        this.load.image('cursed-forest', 'images/territory/cursed-forest.png');
     }
 
     create ()

--- a/src/game/utils/BattleEngine.js
+++ b/src/game/utils/BattleEngine.js
@@ -1,0 +1,44 @@
+/**
+ * 전투 로직의 기반이 되는 엔진
+ * 현재는 간단한 구조만 제공하며, 이후 전투 기능 구현 시 확장될 예정이다.
+ */
+class BattleEngine {
+    constructor() {
+        this.currentBattle = null;
+    }
+
+    /**
+     * 전투를 초기화한다.
+     * @param {Array<object>} allies - 아군 유닛 목록
+     * @param {Array<object>} enemies - 적군 유닛 목록
+     */
+    startBattle(allies, enemies) {
+        this.currentBattle = {
+            allies,
+            enemies,
+            turn: 0
+        };
+        console.log('Battle started', this.currentBattle);
+    }
+
+    /**
+     * 매 턴 호출되어 전투를 진행한다.
+     * 상세 로직은 추후 구현한다.
+     */
+    update() {
+        if (!this.currentBattle) return;
+        // TODO: turn processing logic
+    }
+
+    /**
+     * 전투를 종료한다.
+     */
+    endBattle() {
+        if (this.currentBattle) {
+            console.log('Battle ended');
+            this.currentBattle = null;
+        }
+    }
+}
+
+export const battleEngine = new BattleEngine();


### PR DESCRIPTION
## Summary
- add a dungeon container to HTML layouts
- load new dungeon assets
- create `DungeonScene` and DOM engine
- add expedition button in the territory grid
- introduce a minimal `BattleEngine`
- style dungeon screen

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687cc2c4db0c8327b5aeb33cca218e51