### PR TITLE
Implement formation screen

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -14,6 +14,7 @@
         <div id="territory-container"></div>
         <div id="dungeon-container"></div>
         <div id="party-container"></div>
+        <div id="formation-container"></div>
         <div id="ui-container"></div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         <div id="territory-container"></div>
         <div id="dungeon-container"></div>
         <div id="party-container"></div>
+        <div id="formation-container"></div>
         <div id="ui-container"></div>
     </div>
     <script type="module" src="src/main.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -524,3 +524,72 @@ body {
     cursor: pointer;
     pointer-events: auto;
 }
+
+/* --- 진형 화면 DOM 스타일 --- */
+#formation-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    pointer-events: none;
+    background-size: cover;
+    background-position: center;
+    display: none;
+}
+
+#formation-stage {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-size: cover;
+    background-position: center;
+    pointer-events: none;
+}
+
+#formation-grid {
+    position: absolute;
+    top: 5%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90%;
+    height: 90%;
+    display: grid;
+    grid-template-columns: repeat(16, 1fr);
+    grid-template-rows: repeat(9, 1fr);
+    pointer-events: auto;
+}
+
+.formation-cell {
+    border: 1px solid rgba(255,255,255,0.3);
+    position: relative;
+}
+
+.formation-cell.ally-area {
+    background-color: rgba(0,0,255,0.1);
+}
+
+.formation-unit {
+    width: 100%;
+    height: 100%;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center bottom;
+    cursor: grab;
+}
+
+#formation-back-button {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    padding: 6px 12px;
+    background-color: rgba(0,0,0,0.7);
+    border: 1px solid #fff;
+    border-radius: 4px;
+    color: #fff;
+    cursor: pointer;
+    pointer-events: auto;
+}

--- a/src/game/dom/FormationDOMEngine.js
+++ b/src/game/dom/FormationDOMEngine.js
@@ -1,0 +1,109 @@
+import { partyEngine } from '../utils/PartyEngine.js';
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+
+export class FormationDOMEngine {
+    constructor(scene, domEngine) {
+        this.scene = scene;
+        this.domEngine = domEngine;
+        this.container = document.getElementById('formation-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'formation-container';
+            document.getElementById('app').appendChild(this.container);
+        }
+        this.grid = null;
+        this.createView();
+    }
+
+    createView() {
+        this.container.style.display = 'block';
+        this.container.style.backgroundImage = 'url(assets/images/battle/battle-stage-arena.png)';
+
+        const stage = document.createElement('div');
+        stage.id = 'formation-stage';
+        this.container.appendChild(stage);
+
+        const grid = document.createElement('div');
+        grid.id = 'formation-grid';
+        this.container.appendChild(grid);
+        this.grid = grid;
+
+        const cols = 16;
+        const rows = 9;
+        let index = 0;
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                const cell = document.createElement('div');
+                cell.className = 'formation-cell';
+                if (c < cols / 2) cell.classList.add('ally-area');
+                cell.dataset.index = index++;
+                cell.dataset.col = c;
+                cell.dataset.row = r;
+                cell.addEventListener('dragover', (e) => e.preventDefault());
+                cell.addEventListener('drop', (e) => this.handleDrop(e, cell));
+                grid.appendChild(cell);
+            }
+        }
+
+        this.placeUnits();
+
+        const backButton = document.createElement('div');
+        backButton.id = 'formation-back-button';
+        backButton.innerText = '← 영지로 돌아가기';
+        backButton.addEventListener('click', () => {
+            this.hide();
+            this.scene.scene.start('TerritoryScene');
+        });
+        this.container.appendChild(backButton);
+    }
+
+    placeUnits() {
+        const partyMembers = partyEngine.getPartyMembers();
+        const allMercs = mercenaryEngine.getAllAlliedMercenaries();
+        const cells = Array.from(this.grid.children).filter(c => c.classList.contains('ally-area'));
+        let cellIndex = 0;
+        partyMembers.forEach(id => {
+            const unit = allMercs.find(m => m.uniqueId === id);
+            if (!unit) return;
+            const cell = cells[cellIndex++];
+            if (!cell) return;
+            const unitDiv = document.createElement('div');
+            unitDiv.className = 'formation-unit';
+            unitDiv.style.backgroundImage = `url(${unit.battleSprite})`;
+            unitDiv.draggable = true;
+            unitDiv.addEventListener('dragstart', (e) => {
+                e.dataTransfer.setData('unit-id', id);
+                e.dataTransfer.setData('from-cell', cell.dataset.index);
+            });
+            cell.appendChild(unitDiv);
+        });
+    }
+
+    handleDrop(e, targetCell) {
+        e.preventDefault();
+        if (!targetCell.classList.contains('ally-area')) return;
+        const unitId = e.dataTransfer.getData('unit-id');
+        const fromIndex = e.dataTransfer.getData('from-cell');
+        if (!unitId || fromIndex === '') return;
+        const fromCell = this.grid.querySelector(`[data-index='${fromIndex}']`);
+        if (!fromCell) return;
+        const draggedUnit = fromCell.firstElementChild;
+        const targetUnit = targetCell.firstElementChild;
+        if (!draggedUnit) return;
+        if (targetUnit) {
+            targetCell.appendChild(draggedUnit);
+            fromCell.appendChild(targetUnit);
+        } else {
+            targetCell.appendChild(draggedUnit);
+        }
+    }
+
+    hide() {
+        this.container.style.display = 'none';
+    }
+
+    destroy() {
+        this.container.innerHTML = '';
+        this.hide();
+    }
+}

--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -22,6 +22,7 @@ export class TerritoryDOMEngine {
                 name: '전사',
                 hireImage: 'assets/images/territory/warrior-hire.png',
                 uiImage: 'assets/images/territory/warrior-ui.png',
+                battleSprite: 'assets/images/unit/warrior.png',
                 description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
                 baseStats: {
                     hp: 120, valor: 10, strength: 15, endurance: 12,
@@ -33,6 +34,7 @@ export class TerritoryDOMEngine {
                 name: '거너',
                 hireImage: 'assets/images/territory/gunner-hire.png',
                 uiImage: 'assets/images/territory/gunner-ui.png',
+                battleSprite: 'assets/images/unit/gunner.png',
                 description: '"한 발, 한 발. 신중하게, 그리고 차갑게."',
                 baseStats: {
                     hp: 80, valor: 5, strength: 7, endurance: 6,
@@ -49,6 +51,8 @@ export class TerritoryDOMEngine {
         this.addPartyManagementButton(1, 0);
         // --- 출정 버튼 추가 ---
         this.addExpeditionButton(2, 0);
+        // --- 진형 관리 버튼 추가 ---
+        this.addFormationButton(0, 1);
     }
 
     createGrid() {
@@ -118,6 +122,21 @@ export class TerritoryDOMEngine {
         button.addEventListener('click', () => {
             this.container.style.display = 'none';
             this.scene.scene.start('DungeonScene');
+        });
+        this.grid.appendChild(button);
+    }
+
+    addFormationButton(col, row) {
+        const button = document.createElement('div');
+        button.className = 'building-icon';
+        button.style.backgroundImage = `url(assets/images/territory/formation-icon.png)`;
+        button.style.gridColumnStart = col + 1;
+        button.style.gridRowStart = row + 1;
+        button.addEventListener('mouseover', (event) => this.domEngine.showTooltip(event.clientX, event.clientY, '[진형]'));
+        button.addEventListener('mouseout', () => this.domEngine.hideTooltip());
+        button.addEventListener('click', () => {
+            this.container.style.display = 'none';
+            this.scene.scene.start('FormationScene');
         });
         this.grid.appendChild(button);
     }

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -10,6 +10,7 @@ import { GameOver } from './GameOver.js';
 // --- PartyScene import 추가 ---
 import { PartyScene } from './PartyScene.js';
 import { DungeonScene } from './DungeonScene.js';
+import { FormationScene } from './FormationScene.js';
 
 export class Boot extends Scene
 {
@@ -36,6 +37,7 @@ export class Boot extends Scene
         // --- PartyScene 추가 ---
         this.scene.add('PartyScene', PartyScene);
         this.scene.add('DungeonScene', DungeonScene);
+        this.scene.add('FormationScene', FormationScene);
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/FormationScene.js
+++ b/src/game/scenes/FormationScene.js
@@ -1,0 +1,23 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { DOMEngine } from '../utils/DOMEngine.js';
+import { FormationDOMEngine } from '../dom/FormationDOMEngine.js';
+
+export class FormationScene extends Scene {
+    constructor() {
+        super('FormationScene');
+        this.formationDomEngine = null;
+    }
+
+    create() {
+        const territoryContainer = document.getElementById('territory-container');
+        if (territoryContainer) {
+            territoryContainer.style.display = 'none';
+        }
+        const domEngine = new DOMEngine(this);
+        this.formationDomEngine = new FormationDOMEngine(this, domEngine);
+
+        this.events.on('shutdown', () => {
+            this.formationDomEngine.destroy();
+        });
+    }
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -58,6 +58,7 @@ export class Preloader extends Scene
 
         // 게임 씬에서 사용할 전사 이미지를 로드합니다.
         this.load.image('warrior', 'images/unit/warrior.png');
+        this.load.image('gunner', 'images/unit/gunner.png');
 
         // 영지 씬에 사용할 배경 이미지를 로드합니다.
         this.load.image('city-1', 'images/territory/city-1.png');
@@ -75,6 +76,8 @@ export class Preloader extends Scene
         this.load.image('dungeon-icon', 'images/territory/dungeon-icon.png');
         this.load.image('dungeon-scene', 'images/territory/dungeon-scene.png');
         this.load.image('cursed-forest', 'images/territory/cursed-forest.png');
+        this.load.image('formation-icon', 'images/territory/formation-icon.png');
+        this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');
     }
 
     create ()


### PR DESCRIPTION
## Summary
- add `formation-container` to DOM
- load new battle assets and gunner sprite
- allow selecting formation from territory screen
- implement FormationScene and DOM engine with draggable units
- style the formation UI

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687cc8d105e4832797cb7facf9af9201