### PR TITLE
Implement basic battle system skeleton

### DIFF
--- a/src/game/dom/DungeonDOMEngine.js
+++ b/src/game/dom/DungeonDOMEngine.js
@@ -31,7 +31,7 @@ export class DungeonDOMEngine {
         tile.className = 'dungeon-tile';
         tile.style.backgroundImage = 'url(assets/images/territory/cursed-forest.png)';
         tile.addEventListener('click', () => {
-            console.log('저주받은 숲 선택');
+            this.scene.scene.start('CursedForestBattle');
         });
 
         const label = document.createElement('div');

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -11,6 +11,7 @@ import { GameOver } from './GameOver.js';
 import { PartyScene } from './PartyScene.js';
 import { DungeonScene } from './DungeonScene.js';
 import { FormationScene } from './FormationScene.js';
+import { CursedForestBattleScene } from './CursedForestBattleScene.js';
 
 export class Boot extends Scene
 {
@@ -38,6 +39,7 @@ export class Boot extends Scene
         this.scene.add('PartyScene', PartyScene);
         this.scene.add('DungeonScene', DungeonScene);
         this.scene.add('FormationScene', FormationScene);
+        this.scene.add('CursedForestBattle', CursedForestBattleScene);
 
         this.scene.start('Preloader');
     }

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -1,0 +1,43 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { BattleStageManager } from '../utils/BattleStageManager.js';
+import { formationEngine } from '../utils/FormationEngine.js';
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { monsterEngine } from '../utils/MonsterEngine.js';
+
+export class CursedForestBattleScene extends Scene {
+    constructor() {
+        super('CursedForestBattle');
+        this.stageManager = null;
+    }
+
+    create() {
+        // DOM 컨테이너들 숨기기
+        ['dungeon-container','territory-container'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.style.display = 'none';
+        });
+
+        this.stageManager = new BattleStageManager(this);
+        this.stageManager.createStage('battle-stage-cursed-forest');
+
+        // 아군 배치
+        const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
+        const allMercs = mercenaryEngine.getAllAlliedMercenaries();
+        const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
+        formationEngine.applyFormation(this, partyUnits);
+
+        // 적 몬스터 생성 및 배치
+        const monsters = [];
+        for (let i = 0; i < 5; i++) {
+            monsters.push(
+                monsterEngine.spawnMonster({
+                    name: '좀비',
+                    battleSprite: 'zombie',
+                    baseStats: { hp: 50, valor: 0, strength: 5, endurance: 3, agility: 1, intelligence: 0, wisdom: 0, luck: 0 }
+                }, 'enemy')
+            );
+        }
+        formationEngine.placeMonsters(this, monsters, 8);
+    }
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -78,6 +78,10 @@ export class Preloader extends Scene
         this.load.image('cursed-forest', 'images/territory/cursed-forest.png');
         this.load.image('formation-icon', 'images/territory/formation-icon.png');
         this.load.image('battle-stage-arena', 'images/battle/battle-stage-arena.png');
+        this.load.image('battle-stage-cursed-forest', 'images/battle/battle-stage-cursed-forest.png');
+
+        // 몬스터 스프라이트 로드
+        this.load.image('zombie', 'images/unit/zombie.png');
     }
 
     create ()

--- a/src/game/utils/BattleStageManager.js
+++ b/src/game/utils/BattleStageManager.js
@@ -1,0 +1,29 @@
+import { GridEngine } from './GridEngine.js';
+import { formationEngine } from './FormationEngine.js';
+
+/**
+ * 배틀 스테이지의 그리드와 배경을 관리하는 매니저
+ */
+export class BattleStageManager {
+    constructor(scene) {
+        this.scene = scene;
+        this.gridEngine = new GridEngine(scene);
+    }
+
+    /**
+     * 배경 이미지와 그리드를 생성합니다.
+     * @param {string} bgKey 배경 이미지 키
+     */
+    createStage(bgKey) {
+        const { width, height } = this.scene.scale.gameSize;
+        this.scene.add.image(0, 0, bgKey).setOrigin(0);
+        const cellWidth = width / 16;
+        const cellHeight = height / 9;
+        this.gridEngine.createGrid({ x: 0, y: 0, cols: 16, rows: 9, cellWidth, cellHeight });
+        // 그리드 선을 보이지 않게 설정
+        if (this.gridEngine.graphics) {
+            this.gridEngine.graphics.setAlpha(0);
+        }
+        formationEngine.registerGrid(this.gridEngine);
+    }
+}

--- a/src/game/utils/CombatCalculationEngine.js
+++ b/src/game/utils/CombatCalculationEngine.js
@@ -1,0 +1,22 @@
+import { debugCombatLogManager } from '../debug/DebugCombatLogManager.js';
+
+/**
+ * 실제 전투 데미지 계산을 담당하는 엔진
+ */
+class CombatCalculationEngine {
+    /**
+     * 기본 공격 데미지 계산
+     * @param {object} attacker
+     * @param {object} defender
+     * @returns {number} 최종 적용될 데미지
+     */
+    calculateDamage(attacker = {}, defender = {}) {
+        const base = attacker.finalStats?.physicalAttack || 0;
+        const def = defender.finalStats?.physicalDefense || 0;
+        const finalDamage = Math.max(1, base - def);
+        debugCombatLogManager.logAttackCalculation(attacker, defender, base, finalDamage);
+        return finalDamage;
+    }
+}
+
+export const combatCalculationEngine = new CombatCalculationEngine();

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -1,6 +1,11 @@
 class FormationEngine {
     constructor() {
         this.positions = new Map();
+        this.grid = null; // 전투 타일 그리드 참조
+    }
+
+    registerGrid(gridEngine) {
+        this.grid = gridEngine;
     }
 
     setPosition(unitId, cellIndex) {
@@ -13,6 +18,40 @@ class FormationEngine {
 
     removePosition(unitId) {
         this.positions.delete(unitId);
+    }
+
+    /**
+     * 저장된 위치를 기반으로 유닛 스프라이트를 전투 그리드에 배치합니다.
+     * @param {Phaser.Scene} scene 배치가 이루어질 씬
+     * @param {Array<object>} units 유닛 데이터 배열
+     */
+    applyFormation(scene, units) {
+        if (!this.grid) return;
+        units.forEach(unit => {
+            const index = this.getPosition(unit.uniqueId);
+            const cell = this.grid.gridCells[index];
+            if (!cell) return;
+            const sprite = scene.add.image(cell.x, cell.y, unit.battleSprite || unit.spriteKey || unit.id || unit.name);
+            sprite.setData('unitId', unit.uniqueId);
+        });
+    }
+
+    /**
+     * 적군 몬스터를 무작위 위치에 배치합니다.
+     * @param {Phaser.Scene} scene
+     * @param {Array<object>} monsters
+     * @param {number} startCol 적군 배치가 시작될 최소 열
+     */
+    placeMonsters(scene, monsters, startCol = 8) {
+        if (!this.grid) return;
+        const cells = this.grid.gridCells.filter(c => c.col >= startCol && !c.isOccupied);
+        monsters.forEach(mon => {
+            const cell = cells.splice(Math.floor(Math.random() * cells.length), 1)[0];
+            if (!cell) return;
+            cell.isOccupied = true;
+            const sprite = scene.add.image(cell.x, cell.y, mon.battleSprite || mon.spriteKey || mon.id || mon.name);
+            sprite.setData('unitId', mon.uniqueId);
+        });
     }
 }
 

--- a/src/game/utils/GridEngine.js
+++ b/src/game/utils/GridEngine.js
@@ -23,7 +23,7 @@ export class GridEngine {
         debugLogEngine.log('GridEngine', `${cols}x${rows} 그리드를 생성합니다.`);
 
         // 디버깅 목적으로 그리드를 시각적으로 표시할 그래픽스 객체
-        const graphics = this.scene.add.graphics({ lineStyle: { width: 2, color: 0x00ff00, alpha: 0.5 } });
+        this.graphics = this.scene.add.graphics({ lineStyle: { width: 2, color: 0x00ff00, alpha: 0.5 } });
 
         for (let row = 0; row < rows; row++) {
             for (let col = 0; col < cols; col++) {
@@ -43,7 +43,7 @@ export class GridEngine {
                 this.gridCells.push(cell);
 
                 // 디버깅용 사각형을 그립니다. 나중에 이 부분만 주석 처리하면 보이지 않게 됩니다.
-                graphics.strokeRect(cellX, cellY, cellWidth, cellHeight);
+                this.graphics.strokeRect(cellX, cellY, cellWidth, cellHeight);
             }
         }
     }

--- a/src/game/utils/MonsterEngine.js
+++ b/src/game/utils/MonsterEngine.js
@@ -1,0 +1,48 @@
+import { statEngine } from './StatEngine.js';
+import { birthReportManager } from '../debug/BirthReportManager.js';
+
+/**
+ * 몬스터의 생성과 관리를 담당하는 엔진
+ */
+class MonsterEngine {
+    constructor() {
+        this.alliedMonsters = new Map();
+        this.enemyMonsters = new Map();
+        this.nextId = 1;
+    }
+
+    /**
+     * 몬스터를 생성하여 등록합니다.
+     * @param {object} baseData 기본 몬스터 데이터
+     * @param {string} type 'ally' 또는 'enemy'
+     * @returns {object} 생성된 몬스터 인스턴스
+     */
+    spawnMonster(baseData = {}, type = 'enemy') {
+        const id = this.nextId++;
+        const instance = {
+            ...baseData,
+            uniqueId: id,
+            instanceName: baseData.instanceName || baseData.name || `Monster${id}`,
+        };
+
+        instance.finalStats = statEngine.calculateStats(instance, baseData.baseStats || {}, []);
+
+        if (type === 'ally') {
+            this.alliedMonsters.set(id, instance);
+            birthReportManager.logNewUnit(instance, '아군 몬스터');
+        } else {
+            this.enemyMonsters.set(id, instance);
+            birthReportManager.logNewUnit(instance, '적군 몬스터');
+        }
+        return instance;
+    }
+
+    /**
+     * 특정 진영의 모든 몬스터 배열을 반환합니다.
+     */
+    getAllMonsters(type = 'enemy') {
+        return Array.from(type === 'ally' ? this.alliedMonsters.values() : this.enemyMonsters.values());
+    }
+}
+
+export const monsterEngine = new MonsterEngine();


### PR DESCRIPTION
## Summary
- load cursed forest stage and zombie sprites
- hook dungeon tile to start battle scene
- create CursedForestBattleScene and simple stage/monster engines
- expand formation engine to apply formation in battle
- hide battle grid lines and manage stage setup
- update boot scene with new battle scene

## Testing
- `python3 -m http.server 8000 &`
- `curl -s http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687cd5e830cc8327866cbbe8d78cce1d