### PR TITLE
Implement battle scene cleanup

### DIFF
--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -39,5 +39,16 @@ export class CursedForestBattleScene extends Scene {
             );
         }
         formationEngine.placeMonsters(this, monsters, 8);
+
+        this.events.on('shutdown', () => {
+            ['dungeon-container', 'territory-container'].forEach(id => {
+                const el = document.getElementById(id);
+                if (el) el.style.display = 'block';
+            });
+
+            if (this.stageManager) {
+                this.stageManager.destroy();
+            }
+        });
     }
 }

--- a/src/game/utils/BattleStageManager.js
+++ b/src/game/utils/BattleStageManager.js
@@ -26,4 +26,14 @@ export class BattleStageManager {
         }
         formationEngine.registerGrid(this.gridEngine);
     }
+
+    /**
+     * 생성한 그리드를 정리합니다.
+     */
+    destroy() {
+        if (this.gridEngine && this.gridEngine.graphics) {
+            this.gridEngine.graphics.destroy();
+            this.gridEngine.graphics = null;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- clean up `BattleStageManager` grid graphics
- restore DOM containers when leaving CursedForestBattleScene

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687cdecb9ee883278d053d3f2038bac9