### PR TITLE
Fix scaling and mercenary sprite display

### DIFF
--- a/src/game/dom/TerritoryDOMEngine.js
+++ b/src/game/dom/TerritoryDOMEngine.js
@@ -23,6 +23,7 @@ export class TerritoryDOMEngine {
                 hireImage: 'assets/images/territory/warrior-hire.png',
                 uiImage: 'assets/images/territory/warrior-ui.png',
                 battleSprite: 'assets/images/unit/warrior.png',
+                spriteKey: 'warrior',
                 description: '"그는 단 한 사람을 지키기 위해 검을 든다."',
                 baseStats: {
                     hp: 120, valor: 10, strength: 15, endurance: 12,
@@ -35,6 +36,7 @@ export class TerritoryDOMEngine {
                 hireImage: 'assets/images/territory/gunner-hire.png',
                 uiImage: 'assets/images/territory/gunner-ui.png',
                 battleSprite: 'assets/images/unit/gunner.png',
+                spriteKey: 'gunner',
                 description: '"한 발, 한 발. 신중하게, 그리고 차갑게."',
                 baseStats: {
                     hp: 80, valor: 5, strength: 7, endurance: 6,

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -31,8 +31,10 @@ class FormationEngine {
             const index = this.getPosition(unit.uniqueId);
             const cell = this.grid.gridCells[index];
             if (!cell) return;
-            const sprite = scene.add.image(cell.x, cell.y, unit.battleSprite || unit.spriteKey || unit.id || unit.name);
+            const spriteKey = unit.spriteKey || unit.battleSprite || unit.id || unit.name;
+            const sprite = scene.add.image(cell.x, cell.y, spriteKey);
             sprite.setData('unitId', unit.uniqueId);
+            sprite.setDisplaySize(cell.width, cell.height);
         });
     }
 
@@ -49,8 +51,10 @@ class FormationEngine {
             const cell = cells.splice(Math.floor(Math.random() * cells.length), 1)[0];
             if (!cell) return;
             cell.isOccupied = true;
-            const sprite = scene.add.image(cell.x, cell.y, mon.battleSprite || mon.spriteKey || mon.id || mon.name);
+            const spriteKey = mon.spriteKey || mon.battleSprite || mon.id || mon.name;
+            const sprite = scene.add.image(cell.x, cell.y, spriteKey);
             sprite.setData('unitId', mon.uniqueId);
+            sprite.setDisplaySize(cell.width, cell.height);
         });
     }
 }


### PR DESCRIPTION
## Summary
- scale all battle sprites to match grid cell size
- register Phaser texture keys for mercenaries so images load correctly

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687cdfcc910883279a51227e64bb5684