### PR TITLE
Improve sprite and stage rendering quality

### DIFF
--- a/src/game/utils/BattleStageManager.js
+++ b/src/game/utils/BattleStageManager.js
@@ -16,7 +16,9 @@ export class BattleStageManager {
      */
     createStage(bgKey) {
         const { width, height } = this.scene.scale.gameSize;
-        this.scene.add.image(0, 0, bgKey).setOrigin(0);
+        const bg = this.scene.add.image(0, 0, bgKey).setOrigin(0);
+        // 배경 이미지를 현재 캔버스 크기에 맞게 조정하여 해상도 손실을 방지합니다.
+        bg.setDisplaySize(width, height);
         const cellWidth = width / 16;
         const cellHeight = height / 9;
         this.gridEngine.createGrid({ x: 0, y: 0, cols: 16, rows: 9, cellWidth, cellHeight });

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -34,7 +34,16 @@ class FormationEngine {
             const spriteKey = unit.spriteKey || unit.battleSprite || unit.id || unit.name;
             const sprite = scene.add.image(cell.x, cell.y, spriteKey);
             sprite.setData('unitId', unit.uniqueId);
-            sprite.setDisplaySize(cell.width, cell.height);
+            const texture = scene.textures.get(spriteKey);
+            if (texture && texture.source[0]) {
+                const scale = Math.min(
+                    cell.width / texture.source[0].width,
+                    cell.height / texture.source[0].height
+                );
+                sprite.setScale(scale);
+            } else {
+                sprite.setDisplaySize(cell.width, cell.height);
+            }
         });
     }
 
@@ -54,7 +63,16 @@ class FormationEngine {
             const spriteKey = mon.spriteKey || mon.battleSprite || mon.id || mon.name;
             const sprite = scene.add.image(cell.x, cell.y, spriteKey);
             sprite.setData('unitId', mon.uniqueId);
-            sprite.setDisplaySize(cell.width, cell.height);
+            const texture = scene.textures.get(spriteKey);
+            if (texture && texture.source[0]) {
+                const scale = Math.min(
+                    cell.width / texture.source[0].width,
+                    cell.height / texture.source[0].height
+                );
+                sprite.setScale(scale);
+            } else {
+                sprite.setDisplaySize(cell.width, cell.height);
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- scale battle stage backgrounds to fit the canvas
- preserve sprite aspect ratio when placing units and monsters

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687ce3bc779883278237882b2aaa4298