### PR TITLE
Add canvas compatibility manager

### DIFF
--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -12,6 +12,7 @@ import { PartyScene } from './PartyScene.js';
 import { DungeonScene } from './DungeonScene.js';
 import { FormationScene } from './FormationScene.js';
 import { CursedForestBattleScene } from './CursedForestBattleScene.js';
+import { CompatibilityManager } from '../utils/CompatibilityManager.js';
 
 export class Boot extends Scene
 {
@@ -40,6 +41,9 @@ export class Boot extends Scene
         this.scene.add('DungeonScene', DungeonScene);
         this.scene.add('FormationScene', FormationScene);
         this.scene.add('CursedForestBattle', CursedForestBattleScene);
+
+        // 창 크기에 따라 오버레이 캔버스 해상도를 조정하는 매니저를 초기화합니다.
+        this.compatibilityManager = new CompatibilityManager();
 
         this.scene.start('Preloader');
     }

--- a/src/game/utils/CanvasRenderer.js
+++ b/src/game/utils/CanvasRenderer.js
@@ -1,0 +1,25 @@
+export class CanvasRenderer {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+        this.pixelRatio = window.devicePixelRatio || 1;
+    }
+
+    /**
+     * 캔버스 내부의 그리기 버퍼 해상도를 실제 표시 크기 및 픽셀 비율에 맞춰 조정합니다.
+     * @param {number} displayWidth - 캔버스의 CSS 표시 너비
+     * @param {number} displayHeight - 캔버스의 CSS 표시 높이
+     */
+    resizeCanvas(displayWidth = this.canvas.clientWidth, displayHeight = this.canvas.clientHeight) {
+        // 캔버스의 내부 해상도를 (CSS 표시 크기 * pixelRatio)로 설정합니다.
+        // 이렇게 하면 고해상도 디스플레이에서 이미지가 뭉개지지 않고 선명하게 보입니다.
+        this.canvas.width = displayWidth * this.pixelRatio;
+        this.canvas.height = displayHeight * this.pixelRatio;
+
+        // 모든 그리기 작업에 대해 픽셀 비율만큼 스케일을 적용하여
+        // 코드는 기존 CSS 픽셀 단위로 작업하면서도 물리적 픽셀에 맞게 그려지도록 합니다.
+        this.ctx.scale(this.pixelRatio, this.pixelRatio);
+
+        console.log(`[Renderer] Canvas internal resolution set to: ${this.canvas.width}x${this.canvas.height} (Display: ${displayWidth}x${displayHeight}, Ratio: ${this.pixelRatio})`);
+    }
+}

--- a/src/game/utils/CompatibilityManager.js
+++ b/src/game/utils/CompatibilityManager.js
@@ -1,0 +1,45 @@
+import { CanvasRenderer } from './CanvasRenderer.js';
+
+/**
+ * 게임 전역 캔버스 호환성 관리를 담당하는 매니저
+ * 창 크기 변경 시 캔버스 해상도를 자동으로 조정합니다.
+ */
+export class CompatibilityManager {
+    constructor() {
+        // 게임 캔버스 위에 별도의 오버레이 캔버스를 생성합니다.
+        this.canvas = document.createElement('canvas');
+        this.canvas.id = 'compat-canvas';
+        Object.assign(this.canvas.style, {
+            position: 'absolute',
+            top: '0',
+            left: '0',
+            width: '100%',
+            height: '100%',
+            pointerEvents: 'none'
+        });
+
+        const container = document.getElementById('game-container') || document.body;
+        container.appendChild(this.canvas);
+
+        this.renderer = new CanvasRenderer(this.canvas);
+        this.resizeObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                const { width, height } = entry.contentRect;
+                this.renderer.resizeCanvas(width, height);
+            }
+        });
+        this.resizeObserver.observe(this.canvas);
+
+        // 초기 크기 설정
+        this.renderer.resizeCanvas();
+    }
+
+    destroy() {
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+        }
+        if (this.canvas) {
+            this.canvas.remove();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CanvasRenderer` utility to handle high DPI rendering
- implement `CompatibilityManager` to auto-resize overlay canvas
- initialize compatibility manager in Boot scene

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687ce85d14a083278b157a50a22a64e3