### PR TITLE
Improve responsive DOM layout and sync

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,24 +3,36 @@ body {
     padding: 0;
     color: rgba(255, 255, 255, 0.87);
     background-color: #000000;
+    /* 스크롤바가 나타나지 않도록 전체 화면을 고정한다 */
+    overflow: hidden;
 }
 
 #app {
-    width: 100%;
-    height: 100vh;
+    width: 100vw; /* 뷰포트 전체 너비 */
+    height: 100vh; /* 뷰포트 전체 높이 */
     overflow: hidden;
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
-#ui-container {
+#ui-container,
+#territory-container,
+#party-container,
+#dungeon-container,
+#formation-container {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     pointer-events: none;
+    z-index: 10;
+    background-size: cover;
+    background-position: center;
+}
+
+#ui-container {
     overflow: hidden;
     z-index: 100;
 }
@@ -36,31 +48,12 @@ body {
 }
 
 /* --- 영지 화면 DOM 스타일 --- */
-
 #territory-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    pointer-events: none; 
-    background-size: cover;
-    background-position: center;
     background-image: url(../assets/images/territory/city-1.png);
 }
 
 /* --- 용병 관리 화면 DOM 스타일 --- */
 #party-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    pointer-events: none;
-    background-size: cover;
-    background-position: center;
     background-image: url(../assets/images/territory/party-scene.png);
     display: none; /* 초기에는 숨김 */
 }
@@ -89,7 +82,7 @@ body {
 
 #party-reserve-grid {
     position: absolute;
-    top: 35%;
+    bottom: 5%;
     left: 5%;
     width: 90%;
     height: 60%;
@@ -122,25 +115,32 @@ body {
     text-align: center;
 }
 
-#party-back-button {
+#party-back-button,
+#dungeon-back-button,
+#formation-back-button,
+#tavern-back-button {
     position: absolute;
-    top: 20px;
-    left: 20px;
-    padding: 6px 12px;
+    top: 2vw;
+    left: 2vw;
+    padding: clamp(6px, 1vw, 12px);
+    font-size: clamp(16px, 1.5vw, 24px);
     background-color: rgba(0, 0, 0, 0.7);
     border: 1px solid #fff;
     border-radius: 4px;
     color: #fff;
     cursor: pointer;
     pointer-events: auto;
+    z-index: 100;
 }
 
 #territory-grid {
     position: absolute;
-    top: 35%;
-    left: 15%;
-    width: 40%;
-    height: 50%;
+    top: 50%;
+    left: 50%;
+    /* 화면 크기에 따라 크기가 유연하게 변한다 */
+    width: clamp(300px, 40%, 600px);
+    height: clamp(200px, 50%, 400px);
+    transform: translate(-50%, -50%);
     display: grid;
     gap: 15px;
     pointer-events: auto;
@@ -171,17 +171,6 @@ body {
     align-items: center;
 }
 
-#tavern-back-button {
-    position: absolute;
-    top: 20px;
-    left: 20px;
-    padding: 6px 12px;
-    background-color: rgba(0, 0, 0, 0.7);
-    border: 1px solid #fff;
-    border-radius: 4px;
-    color: #fff;
-    cursor: pointer;
-}
 
 #tavern-grid {
     /* position, top, left, transform 속성 제거 */
@@ -293,8 +282,8 @@ body {
 
 #unit-detail-pane {
     /* 가로형 레이아웃을 위해 크기 조정 */
-    width: 1000px;
-    height: 550px;
+    width: clamp(600px, 80vw, 1000px);
+    height: clamp(400px, 80vh, 550px);
     background-color: #2c2a29;
     border: 3px solid #1a1817;
     border-radius: 8px;
@@ -478,16 +467,8 @@ body {
 
 /* --- 출정 화면 DOM 스타일 --- */
 #dungeon-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    pointer-events: none;
-    background-size: cover;
-    background-position: center;
     display: none;
+    background-image: url(../assets/images/territory/dungeon-scene.png);
 }
 
 #dungeon-grid {
@@ -524,31 +505,11 @@ body {
     text-align: center;
 }
 
-#dungeon-back-button {
-    position: absolute;
-    top: 20px;
-    left: 20px;
-    padding: 6px 12px;
-    background-color: rgba(0,0,0,0.7);
-    border: 1px solid #fff;
-    border-radius: 4px;
-    color: #fff;
-    cursor: pointer;
-    pointer-events: auto;
-}
 
 /* --- 진형 화면 DOM 스타일 --- */
 #formation-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    pointer-events: none;
-    background-size: cover;
-    background-position: center;
     display: none;
+    background-image: url(../assets/images/battle/battle-stage-arena.png);
 }
 
 #formation-stage {
@@ -605,15 +566,10 @@ body {
     text-align: center;
 }
 
-#formation-back-button {
-    position: absolute;
-    top: 20px;
-    left: 20px;
-    padding: 6px 12px;
-    background-color: rgba(0,0,0,0.7);
-    border: 1px solid #fff;
-    border-radius: 4px;
-    color: #fff;
-    cursor: pointer;
-    pointer-events: auto;
+/* 작은 화면에서는 영지 그리드의 크기를 조정한다 */
+@media (max-width: 768px) {
+    #territory-grid {
+        width: 80%;
+    }
 }
+

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -23,13 +23,16 @@ const config = {
     transparent: true, // 캔버스 자체를 투명하게 설정합니다.
     backgroundColor: 'transparent', // 배경색을 투명하게 만듭니다.
     scale: {
-        mode: Phaser.Scale.FIT,
+        // 화면을 가득 채우면서도 비율을 유지한다. 일부 영역이 잘릴 수 있음
+        mode: Phaser.Scale.ENVELOP,
         autoCenter: Phaser.Scale.CENTER_BOTH
     },
     render: {
         pixelArt: false,
-        antialias: true, // 안티에일리어싱을 활성화하여 이미지를 부드럽게 표현합니다.
-        resolution: window.devicePixelRatio || 1, // 기기의 픽셀 비율에 맞춰 해상도를 설정합니다.
+        antialias: true,
+        // 고해상도 디스플레이는 Phaser가 자동으로 처리하므로 해상도 값을 고정
+        // 하고 CSS로 크기를 조절하는 편이 안정적이다.
+        resolution: 1,
     },
     // Boot 씬만 초기 설정에 등록합니다.
     // Boot 씬이 실행되면서 나머지 씬들을 동적으로 추가합니다.

--- a/src/game/utils/DomSync.js
+++ b/src/game/utils/DomSync.js
@@ -17,36 +17,38 @@ export class DomSync {
         // CSS transform을 사용하기 위해 position을 absolute로 설정합니다.
         this.domElement.style.position = 'absolute';
         this.domElement.style.willChange = 'transform'; // 브라우저에 렌더링 최적화를 알려줍니다.
-        this.domElement.style.transformOrigin = 'top left'; // 줌인/아웃 시 왼쪽 상단을 기준으로 크기가 조절되도록 합니다.
+        // 스케일링 시 중심을 기준으로 계산하도록 변경
+        this.domElement.style.transformOrigin = 'center center';
     }
 
     /**
      * 이 메소드는 씬의 update 루프 안에서 계속 호출되어야 합니다.
      */
     update() {
-        if (!this.gameObject.scene) {
-            // 게임오브젝트가 파괴된 경우, DOM 요소도 제거합니다.
+        if (!this.gameObject.scene || !this.gameObject.active) {
+            // 게임오브젝트가 파괴되었거나 비활성화된 경우 DOM 요소도 제거합니다.
             this.destroy();
             return;
         }
-        
-        const { x, y } = this.gameObject;
-        const { zoom, scrollX, scrollY } = this.camera;
 
-        // 페이지 내에서 캔버스의 절대 위치를 가져옵니다.
+        // 캔버스의 현재 위치와 크기를 가져옵니다.
         const gameBounds = this.scene.sys.game.canvas.getBoundingClientRect();
 
-        // 카메라의 스크롤과 줌을 고려하여 게임 오브젝트의 화면상 위치를 계산합니다.
+        // 게임 오브젝트의 중심 좌표를 사용하여 위치 계산 오차를 줄입니다.
+        const { x, y } = this.gameObject.getCenter();
+        const { zoom, scrollX, scrollY } = this.camera;
+
+        // 카메라 스크롤과 줌을 고려한 화면상 좌표를 계산합니다.
         const screenX = (x - scrollX) * zoom;
         const screenY = (y - scrollY) * zoom;
 
-        // DOM 요소가 위치할 최종 좌표입니다.
+        // 캔버스의 위치를 기준으로 DOM 요소의 최종 좌표를 결정합니다.
         const domX = gameBounds.left + screenX;
         const domY = gameBounds.top + screenY;
 
-        // transform 속성을 사용하여 DOM 요소의 위치와 크기를 한 번에 적용합니다.
-        // top/left를 직접 바꾸는 것보다 성능상 이점이 있습니다.
-        this.domElement.style.transform = `translate(${domX}px, ${domY}px) scale(${zoom})`;
+        // transform으로 위치와 스케일을 한 번에 적용합니다.
+        this.domElement.style.transform =
+            `translate(-50%, -50%) translate(${domX}px, ${domY}px) scale(${zoom})`;
     }
 
     /**


### PR DESCRIPTION
## Summary
- update CSS to use viewport units and clamped sizes
- adjust DomSync to follow canvas bounds and zoom
- set Phaser scale mode to ENVELOP with fixed resolution

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d0636689c83279bd40e3cdd5f664a