### PR TITLE
Improve texture filtering and stage scaling

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -30,6 +30,7 @@ const config = {
         pixelArt: false,
         antialias: true, // 안티에일리어싱을 활성화하여 이미지를 부드럽게 표현합니다.
         resolution: window.devicePixelRatio || 1, // 기기의 픽셀 비율에 맞춰 해상도를 설정합니다.
+        roundPixels: true,
     },
     // Boot 씬만 초기 설정에 등록합니다.
     // Boot 씬이 실행되면서 나머지 씬들을 동적으로 추가합니다.

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,5 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
 import { imageSizeManager } from '../utils/ImageSizeManager.js';
 
 export class Preloader extends Scene
@@ -86,6 +87,18 @@ export class Preloader extends Scene
 
     create ()
     {
+        // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
+        const battleTextures = [
+            'warrior', 'gunner', 'zombie',
+            'battle-stage-cursed-forest', 'battle-stage-arena'
+        ];
+
+        battleTextures.forEach(key => {
+            if (this.textures.exists(key)) {
+                this.textures.get(key).setFilter(Phaser.Textures.FilterMode.TRILINEAR);
+            }
+        });
+
         // 모든 애셋이 로드되면 영지 씬으로 전환합니다.
         this.scene.start('TerritoryScene');
     }

--- a/src/game/utils/BattleStageManager.js
+++ b/src/game/utils/BattleStageManager.js
@@ -16,9 +16,17 @@ export class BattleStageManager {
      */
     createStage(bgKey) {
         const { width, height } = this.scene.scale.gameSize;
-        const bg = this.scene.add.image(0, 0, bgKey).setOrigin(0);
-        // 배경 이미지를 현재 캔버스 크기에 맞게 조정하여 해상도 손실을 방지합니다.
-        bg.setDisplaySize(width, height);
+        const bg = this.scene.add.image(width / 2, height / 2, bgKey);
+
+        const bgTexture = this.scene.textures.get(bgKey);
+        const bgWidth = bgTexture.source[0].width;
+        const bgHeight = bgTexture.source[0].height;
+
+        const scaleX = width / bgWidth;
+        const scaleY = height / bgHeight;
+
+        const scale = Math.max(scaleX, scaleY);
+        bg.setScale(scale);
         const cellWidth = width / 16;
         const cellHeight = height / 9;
         this.gridEngine.createGrid({ x: 0, y: 0, cols: 16, rows: 9, cellWidth, cellHeight });


### PR DESCRIPTION
## Summary
- enhance filtering of key textures
- keep battle stage aspect ratio intact when scaling
- round pixels for sharper rendering

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d09d96ee883278dd39a6f51bbaff2