### PR TITLE
Use DOM in Cursed Forest battle

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -15,6 +15,7 @@
         <div id="dungeon-container"></div>
         <div id="party-container"></div>
         <div id="formation-container"></div>
+        <div id="battle-container"></div>
         <div id="ui-container"></div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <div id="dungeon-container"></div>
         <div id="party-container"></div>
         <div id="formation-container"></div>
+        <div id="battle-container"></div>
         <div id="ui-container"></div>
     </div>
     <script type="module" src="src/main.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -617,3 +617,43 @@ body {
     cursor: pointer;
     pointer-events: auto;
 }
+
+/* --- 배틀 화면 DOM 스타일 --- */
+#battle-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    pointer-events: none;
+    background-size: cover;
+    background-position: center;
+    display: none;
+}
+
+#battle-grid {
+    position: absolute;
+    top: 5%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90%;
+    height: 90%;
+    display: grid;
+    grid-template-columns: repeat(16, 1fr);
+    grid-template-rows: repeat(9, 1fr);
+    pointer-events: auto;
+}
+
+.battle-cell {
+    border: 1px solid rgba(255,255,255,0.3);
+    position: relative;
+}
+
+.battle-unit {
+    width: 100%;
+    height: 100%;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center bottom;
+}

--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -1,0 +1,69 @@
+import { formationEngine } from '../utils/FormationEngine.js';
+
+export class BattleDOMEngine {
+    constructor(scene) {
+        this.scene = scene;
+        this.container = document.getElementById('battle-container');
+        if (!this.container) {
+            this.container = document.createElement('div');
+            this.container.id = 'battle-container';
+            document.getElementById('app').appendChild(this.container);
+        }
+        this.grid = null;
+    }
+
+    createStage(bgImage) {
+        this.container.style.display = 'block';
+        this.container.style.backgroundImage = `url(${bgImage})`;
+
+        const grid = document.createElement('div');
+        grid.id = 'battle-grid';
+        this.container.appendChild(grid);
+        this.grid = grid;
+
+        const cols = 16;
+        const rows = 9;
+        let index = 0;
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                const cell = document.createElement('div');
+                cell.className = 'battle-cell';
+                cell.dataset.index = index++;
+                cell.dataset.col = c;
+                cell.dataset.row = r;
+                grid.appendChild(cell);
+            }
+        }
+    }
+
+    placeAllies(units) {
+        if (!this.grid) return;
+        units.forEach(unit => {
+            const index = formationEngine.getPosition(unit.uniqueId);
+            const cell = this.grid.querySelector(`[data-index='${index}']`);
+            if (!cell) return;
+            const unitDiv = document.createElement('div');
+            unitDiv.className = 'battle-unit';
+            unitDiv.style.backgroundImage = `url(${unit.battleSprite})`;
+            cell.appendChild(unitDiv);
+        });
+    }
+
+    placeMonsters(monsters, startCol = 8) {
+        if (!this.grid) return;
+        const available = Array.from(this.grid.children).filter(c => parseInt(c.dataset.col) >= startCol && !c.hasChildNodes());
+        monsters.forEach(mon => {
+            const cell = available.splice(Math.floor(Math.random() * available.length), 1)[0];
+            if (!cell) return;
+            const unitDiv = document.createElement('div');
+            unitDiv.className = 'battle-unit';
+            unitDiv.style.backgroundImage = `url(${mon.battleSprite})`;
+            cell.appendChild(unitDiv);
+        });
+    }
+
+    destroy() {
+        this.container.innerHTML = '';
+        this.container.style.display = 'none';
+    }
+}

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -1,6 +1,6 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-import { BattleStageManager } from '../utils/BattleStageManager.js';
-import { formationEngine } from '../utils/FormationEngine.js';
+import { DOMEngine } from '../utils/DOMEngine.js';
+import { BattleDOMEngine } from '../dom/BattleDOMEngine.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
@@ -9,32 +9,30 @@ import { getMonsterBase } from '../data/monster.js';
 export class CursedForestBattleScene extends Scene {
     constructor() {
         super('CursedForestBattle');
-        this.stageManager = null;
+        this.battleDomEngine = null;
     }
 
     create() {
-        // DOM 컨테이너들 숨기기
-        ['dungeon-container','territory-container'].forEach(id => {
+        ['dungeon-container', 'territory-container'].forEach(id => {
             const el = document.getElementById(id);
             if (el) el.style.display = 'none';
         });
 
-        this.stageManager = new BattleStageManager(this);
-        this.stageManager.createStage('battle-stage-cursed-forest');
+        const domEngine = new DOMEngine(this);
+        this.battleDomEngine = new BattleDOMEngine(this, domEngine);
+        this.battleDomEngine.createStage('assets/images/battle/battle-stage-cursed-forest.png');
 
-        // 아군 배치
         const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
         const allMercs = mercenaryEngine.getAllAlliedMercenaries();
         const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
-        formationEngine.applyFormation(this, partyUnits);
+        this.battleDomEngine.placeAllies(partyUnits);
 
-        // 적 몬스터 생성 및 배치
         const monsters = [];
         const zombieBase = getMonsterBase('zombie');
         for (let i = 0; i < 5; i++) {
             monsters.push(monsterEngine.spawnMonster(zombieBase, 'enemy'));
         }
-        formationEngine.placeMonsters(this, monsters, 8);
+        this.battleDomEngine.placeMonsters(monsters, 8);
 
         this.events.on('shutdown', () => {
             ['dungeon-container', 'territory-container'].forEach(id => {
@@ -42,8 +40,8 @@ export class CursedForestBattleScene extends Scene {
                 if (el) el.style.display = 'block';
             });
 
-            if (this.stageManager) {
-                this.stageManager.destroy();
+            if (this.battleDomEngine) {
+                this.battleDomEngine.destroy();
             }
         });
     }


### PR DESCRIPTION
## Summary
- add battle container markup
- style DOM-based battle grid
- implement `BattleDOMEngine`
- convert `CursedForestBattleScene` to use DOM engine

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d0f62194483279a02799d43b8cfaf