### PR TITLE
Implement turn-based battle core with worker

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -660,4 +660,23 @@ body {
     background-repeat: no-repeat;
     background-position: center bottom;
     will-change: transform;
+    position: relative;
+}
+
+.battle-unit-name {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    font-size: 12px;
+    text-align: center;
+    color: #fff;
+}
+
+.battle-unit-name.ally {
+    background-color: rgba(0, 0, 255, 0.6);
+}
+
+.battle-unit-name.enemy {
+    background-color: rgba(255, 0, 0, 0.6);
 }

--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -56,6 +56,10 @@ export class BattleDOMEngine {
             const unitDiv = document.createElement('div');
             unitDiv.className = 'battle-unit';
             unitDiv.style.backgroundImage = `url(${unit.battleSprite})`;
+            const name = document.createElement('div');
+            name.className = 'battle-unit-name ally';
+            name.innerText = unit.instanceName || unit.name;
+            unitDiv.appendChild(name);
             cell.appendChild(unitDiv);
         });
     }
@@ -69,6 +73,10 @@ export class BattleDOMEngine {
             const unitDiv = document.createElement('div');
             unitDiv.className = 'battle-unit';
             unitDiv.style.backgroundImage = `url(${mon.battleSprite})`;
+            const name = document.createElement('div');
+            name.className = 'battle-unit-name enemy';
+            name.innerText = mon.instanceName || mon.name;
+            unitDiv.appendChild(name);
             cell.appendChild(unitDiv);
         });
     }

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -5,6 +5,7 @@ import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
+import { battleEngine } from '../utils/BattleEngine.js';
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
@@ -34,6 +35,8 @@ export class CursedForestBattleScene extends Scene {
         }
         this.battleDomEngine.placeMonsters(monsters, 8);
 
+        battleEngine.startBattle(partyUnits, monsters);
+
         this.events.on('shutdown', () => {
             ['dungeon-container', 'territory-container'].forEach(id => {
                 const el = document.getElementById(id);
@@ -43,6 +46,11 @@ export class CursedForestBattleScene extends Scene {
             if (this.battleDomEngine) {
                 this.battleDomEngine.destroy();
             }
+            battleEngine.endBattle();
         });
+    }
+
+    update() {
+        battleEngine.update();
     }
 }

--- a/src/game/utils/BattleEngine.js
+++ b/src/game/utils/BattleEngine.js
@@ -2,9 +2,13 @@
  * 전투 로직의 기반이 되는 엔진
  * 현재는 간단한 구조만 제공하며, 이후 전투 기능 구현 시 확장될 예정이다.
  */
+import { turnEngine } from './TurnEngine.js';
+import { delayEngine } from './DelayEngine.js';
+
 class BattleEngine {
     constructor() {
         this.currentBattle = null;
+        this.worker = null;
     }
 
     /**
@@ -13,11 +17,11 @@ class BattleEngine {
      * @param {Array<object>} enemies - 적군 유닛 목록
      */
     startBattle(allies, enemies) {
-        this.currentBattle = {
-            allies,
-            enemies,
-            turn: 0
-        };
+        this.currentBattle = { allies, enemies };
+        turnEngine.init(allies, enemies);
+
+        const workerUrl = new URL('../workers/battleWorker.js', import.meta.url);
+        this.worker = new Worker(workerUrl, { type: 'module' });
         console.log('Battle started', this.currentBattle);
     }
 
@@ -25,9 +29,19 @@ class BattleEngine {
      * 매 턴 호출되어 전투를 진행한다.
      * 상세 로직은 추후 구현한다.
      */
-    update() {
-        if (!this.currentBattle) return;
-        // TODO: turn processing logic
+    async update() {
+        if (!this.currentBattle || delayEngine.isHolding()) return;
+
+        const unit = turnEngine.getCurrentUnit();
+        if (!unit) return;
+        const targetList = unit.type === 'ally' ? this.currentBattle.enemies : this.currentBattle.allies;
+        const target = targetList.find(t => t.finalStats?.hp > 0);
+        if (!target) return;
+
+        const damage = await this.calculateDamage(unit, target);
+        target.finalStats.hp = Math.max(0, (target.finalStats.hp || 0) - damage);
+        await delayEngine.hold(300);
+        turnEngine.advance();
     }
 
     /**
@@ -37,7 +51,26 @@ class BattleEngine {
         if (this.currentBattle) {
             console.log('Battle ended');
             this.currentBattle = null;
+            if (this.worker) {
+                this.worker.terminate();
+                this.worker = null;
+            }
         }
+    }
+
+    calculateDamage(attacker, defender) {
+        return new Promise(resolve => {
+            if (!this.worker) {
+                resolve(0);
+                return;
+            }
+            const handler = e => {
+                this.worker.removeEventListener('message', handler);
+                resolve(e.data.damage || 0);
+            };
+            this.worker.addEventListener('message', handler);
+            this.worker.postMessage({ cmd: 'calculateDamage', attacker, defender });
+        });
     }
 }
 

--- a/src/game/utils/DelayEngine.js
+++ b/src/game/utils/DelayEngine.js
@@ -1,0 +1,17 @@
+class DelayEngine {
+    constructor() {
+        this.holding = false;
+    }
+
+    async hold(ms = 0) {
+        this.holding = true;
+        await new Promise(resolve => setTimeout(resolve, ms));
+        this.holding = false;
+    }
+
+    isHolding() {
+        return this.holding;
+    }
+}
+
+export const delayEngine = new DelayEngine();

--- a/src/game/utils/TurnEngine.js
+++ b/src/game/utils/TurnEngine.js
@@ -1,0 +1,26 @@
+class TurnEngine {
+    constructor() {
+        this.turnQueue = [];
+        this.currentIndex = 0;
+    }
+
+    init(allies = [], enemies = []) {
+        this.turnQueue = [...allies, ...enemies].sort((a, b) => {
+            const aTurn = a.finalStats?.turnValue || 0;
+            const bTurn = b.finalStats?.turnValue || 0;
+            return aTurn - bTurn;
+        });
+        this.currentIndex = 0;
+    }
+
+    getCurrentUnit() {
+        return this.turnQueue[this.currentIndex];
+    }
+
+    advance() {
+        if (this.turnQueue.length === 0) return;
+        this.currentIndex = (this.currentIndex + 1) % this.turnQueue.length;
+    }
+}
+
+export const turnEngine = new TurnEngine();

--- a/src/game/workers/battleWorker.js
+++ b/src/game/workers/battleWorker.js
@@ -1,0 +1,9 @@
+self.onmessage = (e) => {
+    const { cmd, attacker, defender } = e.data;
+    if (cmd === 'calculateDamage') {
+        const base = attacker?.finalStats?.physicalAttack || 0;
+        const def = defender?.finalStats?.physicalDefense || 0;
+        const damage = Math.max(1, base - def);
+        self.postMessage({ damage });
+    }
+};


### PR DESCRIPTION
## Summary
- implement a `TurnEngine` to manage unit order
- add `DelayEngine` to pause turns while animations play
- create a `battleWorker` and connect it in `BattleEngine`
- show ally and enemy names in `BattleDOMEngine`
- display nameplates with blue/red backgrounds via CSS
- start and run the battle engine in `CursedForestBattleScene`

## Testing
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d1a2a90ac832799b2bf1cea9f1f02