### PR TITLE
Fix zombie path for DOM spawn

### DIFF
--- a/src/game/data/monster.js
+++ b/src/game/data/monster.js
@@ -1,7 +1,7 @@
 export const monsterData = {
     zombie: {
         name: '좀비',
-        battleSprite: 'zombie',
+        battleSprite: 'assets/images/unit/zombie.png',
         baseStats: { hp: 50, valor: 0, strength: 5, endurance: 3, agility: 1, intelligence: 0, wisdom: 0, luck: 0 }
     }
 };


### PR DESCRIPTION
## Summary
- fix path to zombie sprite in `monster.js` so DOM elements can load correctly

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687d1b907ac083278ac4789cc831e46d