### PR TITLE
Fix battle stage zoom

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -630,6 +630,8 @@ body {
     pointer-events: auto; /* allow wheel events for zoom */
     background-size: cover;
     background-position: center;
+    transform: scale(var(--battle-zoom, 1));
+    transform-origin: center;
     display: none;
 }
 
@@ -637,7 +639,7 @@ body {
     position: absolute;
     top: 5%;
     left: 50%;
-    transform: translate(-50%, 0) scale(var(--battle-zoom, 1));
+    transform: translate(-50%, 0);
     transform-origin: center;
     width: 90%;
     height: 90%;

--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -22,13 +22,13 @@ export class BattleDOMEngine {
         grid.id = 'battle-grid';
         this.container.appendChild(grid);
         this.grid = grid;
-        this.grid.style.setProperty('--battle-zoom', this.zoom);
+        this.container.style.setProperty('--battle-zoom', this.zoom);
 
         this._wheelHandler = (e) => {
             e.preventDefault();
             const delta = e.deltaY * -0.001;
             this.zoom = Math.min(2, Math.max(0.5, this.zoom + delta));
-            this.grid.style.setProperty('--battle-zoom', this.zoom);
+            this.container.style.setProperty('--battle-zoom', this.zoom);
         };
         this.grid.addEventListener('wheel', this._wheelHandler, { passive: false });
 


### PR DESCRIPTION
## Summary
- scale entire battle container with --battle-zoom variable so background image zooms properly
- update BattleDOMEngine to apply zoom variable on container

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687f2c3f25988327abb38ec383049eba