### PR TITLE
Add SampleBattleScene entry

### DIFF
--- a/src/game/dom/DungeonDOMEngine.js
+++ b/src/game/dom/DungeonDOMEngine.js
@@ -39,6 +39,20 @@ export class DungeonDOMEngine {
         label.innerText = '[저주받은 숲]';
         tile.appendChild(label);
         grid.appendChild(tile);
+
+        // --- 샘플 배틀 타일 추가 ---
+        const sampleTile = document.createElement('div');
+        sampleTile.className = 'dungeon-tile';
+        sampleTile.style.border = '2px dashed yellow';
+        sampleTile.addEventListener('click', () => {
+            this.scene.scene.start('SampleBattleScene');
+        });
+
+        const sampleLabel = document.createElement('div');
+        sampleLabel.className = 'dungeon-label';
+        sampleLabel.innerText = '[샘플 배틀]';
+        sampleTile.appendChild(sampleLabel);
+        grid.appendChild(sampleTile);
     }
 
     destroy() {
@@ -46,3 +60,4 @@ export class DungeonDOMEngine {
         this.container.style.display = 'none';
     }
 }
+

--- a/src/game/scenes/Boot.js
+++ b/src/game/scenes/Boot.js
@@ -12,6 +12,7 @@ import { PartyScene } from './PartyScene.js';
 import { DungeonScene } from './DungeonScene.js';
 import { FormationScene } from './FormationScene.js';
 import { CursedForestBattleScene } from './CursedForestBattleScene.js';
+import { SampleBattleScene } from './SampleBattleScene.js';
 
 export class Boot extends Scene
 {
@@ -40,7 +41,9 @@ export class Boot extends Scene
         this.scene.add('DungeonScene', DungeonScene);
         this.scene.add('FormationScene', FormationScene);
         this.scene.add('CursedForestBattle', CursedForestBattleScene);
+        this.scene.add('SampleBattleScene', SampleBattleScene);
 
         this.scene.start('Preloader');
     }
 }
+

--- a/src/game/scenes/SampleBattleScene.js
+++ b/src/game/scenes/SampleBattleScene.js
@@ -1,0 +1,57 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { DOMEngine } from '../utils/DOMEngine.js';
+import { BattleDOMEngine } from '../dom/BattleDOMEngine.js';
+import { mercenaryEngine } from '../utils/MercenaryEngine.js';
+import { partyEngine } from '../utils/PartyEngine.js';
+import { monsterEngine } from '../utils/MonsterEngine.js';
+import { getMonsterBase } from '../data/monster.js';
+import { battleEngine } from '../utils/BattleEngine.js';
+
+export class SampleBattleScene extends Scene {
+    constructor() {
+        super('SampleBattleScene');
+        this.battleDomEngine = null;
+    }
+
+    create() {
+        ['dungeon-container', 'territory-container'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.style.display = 'none';
+        });
+
+        const domEngine = new DOMEngine(this);
+        this.battleDomEngine = new BattleDOMEngine(this, domEngine);
+        this.battleDomEngine.createStage('assets/images/battle/battle-stage-cursed-forest.png');
+
+        const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
+        const allMercs = mercenaryEngine.getAllAlliedMercenaries();
+        const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
+        this.battleDomEngine.placeAllies(partyUnits);
+
+        const monsters = [];
+        const zombieBase = getMonsterBase('zombie');
+        for (let i = 0; i < 5; i++) {
+            monsters.push(monsterEngine.spawnMonster(zombieBase, 'enemy'));
+        }
+        this.battleDomEngine.placeMonsters(monsters, 8);
+
+        battleEngine.startBattle(partyUnits, monsters);
+
+        this.events.on('shutdown', () => {
+            ['dungeon-container', 'territory-container'].forEach(id => {
+                const el = document.getElementById(id);
+                if (el) el.style.display = 'block';
+            });
+
+            if (this.battleDomEngine) {
+                this.battleDomEngine.destroy();
+            }
+            battleEngine.endBattle();
+        });
+    }
+
+    update() {
+        battleEngine.update();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new SampleBattleScene derived from CursedForestBattleScene
- register SampleBattleScene in Boot
- add placeholder dungeon tile that loads SampleBattleScene when clicked

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f2f9943ac8327a38c3926b5ed9d0a