### PR TITLE
Implement BindingManager and turn animations

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -718,3 +718,51 @@ body {
 .battle-unit-name.enemy {
     background-color: rgba(255, 0, 0, 0.6);
 }
+/* --- 유닛 아이들 애니메이션 --- */
+@keyframes idle-float {
+    0% {
+        transform: translateY(0px);
+    }
+    50% {
+        transform: translateY(-5px);
+    }
+    100% {
+        transform: translateY(0px);
+    }
+}
+
+.battle-unit.is-turn {
+    /* 1.5초 동안 위아래로 부드럽게 움직이는 애니메이션 적용 */
+    animation: idle-float 1.5s ease-in-out infinite;
+}
+
+/* --- 바인딩된 UI 요소 스타일 (예: 이름표) --- */
+.bound-ui-element {
+    position: absolute;
+    width: max-content;
+    padding: 2px 4px;
+    font-size: 12px;
+    font-weight: bold;
+    text-align: center;
+    color: #fff;
+    text-shadow: 0 0 2px #000;
+    pointer-events: none;
+    z-index: 1;
+    /* 성능을 위해 will-change 속성 추가 */
+    will-change: transform;
+    transition: transform 0.1s linear; /* 부드러운 위치 동기화를 위함 */
+}
+
+.bound-ui-element.ally {
+    background-color: rgba(0, 0, 255, 0.6);
+    bottom: 2px; /* 유닛 발밑에 위치 */
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.bound-ui-element.enemy {
+    background-color: rgba(255, 0, 0, 0.6);
+    bottom: 2px; /* 유닛 발밑에 위치 */
+    left: 50%;
+    transform: translateX(-50%);
+}

--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -1,4 +1,6 @@
 import { formationEngine } from '../utils/FormationEngine.js';
+// --- (수정) 바인딩 매니저 import ---
+import { bindingManager } from '../utils/BindingManager.js';
 
 export class BattleDOMEngine {
     constructor(scene) {
@@ -121,12 +123,14 @@ export class BattleDOMEngine {
             if (!cell) return;
             const unitDiv = document.createElement('div');
             unitDiv.className = 'battle-unit';
+            // --- (수정) 유닛 식별을 위한 데이터 속성 추가 ---
+            unitDiv.dataset.unitId = unit.uniqueId;
             unitDiv.style.backgroundImage = `url(${unit.battleSprite})`;
-            const name = document.createElement('div');
-            name.className = 'battle-unit-name ally';
-            name.innerText = unit.instanceName || unit.name;
-            unitDiv.appendChild(name);
+
             cell.appendChild(unitDiv);
+
+            // --- (수정) 바인딩 매니저에 유닛 등록 ---
+            bindingManager.bindUnit(unit, unitDiv);
         });
     }
 
@@ -138,12 +142,14 @@ export class BattleDOMEngine {
             if (!cell) return;
             const unitDiv = document.createElement('div');
             unitDiv.className = 'battle-unit';
+            // --- (수정) 유닛 식별을 위한 데이터 속성 추가 ---
+            unitDiv.dataset.unitId = mon.uniqueId;
             unitDiv.style.backgroundImage = `url(${mon.battleSprite})`;
-            const name = document.createElement('div');
-            name.className = 'battle-unit-name enemy';
-            name.innerText = mon.instanceName || mon.name;
-            unitDiv.appendChild(name);
+
             cell.appendChild(unitDiv);
+
+            // --- (수정) 바인딩 매니저에 유닛 등록 ---
+            bindingManager.bindUnit(mon, unitDiv);
         });
     }
 
@@ -157,5 +163,7 @@ export class BattleDOMEngine {
             this.container.removeEventListener('mouseup', this._mouseUpHandler);
             this.container.removeEventListener('mouseleave', this._mouseLeaveHandler);
         }
+        // --- (수정) 씬 종료 시 바인딩 매니저 클리어 ---
+        bindingManager.clear();
     }
 }

--- a/src/game/scenes/SampleBattleScene.js
+++ b/src/game/scenes/SampleBattleScene.js
@@ -1,16 +1,20 @@
 import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-import { DOMEngine } from '../utils/DOMEngine.js';
 import { BattleDOMEngine } from '../dom/BattleDOMEngine.js';
 import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
 import { battleEngine } from '../utils/BattleEngine.js';
+// --- (수정) 바인딩 매니저와 턴 엔진 import ---
+import { bindingManager } from '../utils/BindingManager.js';
+import { turnEngine } from '../utils/TurnEngine.js';
 
 export class SampleBattleScene extends Scene {
     constructor() {
         super('SampleBattleScene');
         this.battleDomEngine = null;
+        // --- (추가) 현재 턴 유닛의 DOM 요소를 저장할 변수 ---
+        this.currentTurnUnitElement = null;
     }
 
     create() {
@@ -19,23 +23,41 @@ export class SampleBattleScene extends Scene {
             if (el) el.style.display = 'none';
         });
 
-        const domEngine = new DOMEngine(this);
-        this.battleDomEngine = new BattleDOMEngine(this, domEngine);
-        this.battleDomEngine.createStage('assets/images/battle/battle-stage-cursed-forest.png');
+        // BattleDOMEngine은 Phaser 씬이 아닌 DOM을 직접 제어하므로 DOMEngine은 필요 없습니다.
+        this.battleDomEngine = new BattleDOMEngine(this);
+        this.battleDomEngine.createStage('assets/images/battle/battle-stage-arena.png');
 
         const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
         const allMercs = mercenaryEngine.getAllAlliedMercenaries();
-        const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
+        let partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
+        
+        // --- (수정) 테스트를 위해 아군 유닛이 없으면 워리어를 하나 추가합니다. ---
+        if (partyUnits.length === 0) {
+            const warriorData = mercenaryEngine.mercenaries.warrior;
+            partyUnits.push(mercenaryEngine.hireMercenary(warriorData, 'ally'));
+        }
+        
         this.battleDomEngine.placeAllies(partyUnits);
 
         const monsters = [];
         const zombieBase = getMonsterBase('zombie');
         for (let i = 0; i < 5; i++) {
-            monsters.push(monsterEngine.spawnMonster(zombieBase, 'enemy'));
+            const newZombie = monsterEngine.spawnMonster(zombieBase, 'enemy');
+            // --- (추가) 몬스터 타입을 명시적으로 지정 ---
+            newZombie.type = 'enemy';
+            monsters.push(newZombie);
         }
         this.battleDomEngine.placeMonsters(monsters, 8);
 
+        // --- (수정) partyUnits에 type 속성 추가 ---
+        partyUnits.forEach(u => u.type = 'ally');
+
         battleEngine.startBattle(partyUnits, monsters);
+
+        // --- (추가) 턴 변경 이벤트 리스너 등록 ---
+        turnEngine.events.on('turn-changed', this.onTurnChanged, this);
+        // --- (추가) 초기 턴 설정 ---
+        this.onTurnChanged(turnEngine.getCurrentUnit());
 
         this.events.on('shutdown', () => {
             ['dungeon-container', 'territory-container'].forEach(id => {
@@ -47,11 +69,35 @@ export class SampleBattleScene extends Scene {
                 this.battleDomEngine.destroy();
             }
             battleEngine.endBattle();
+            // --- (추가) 씬 종료 시 이벤트 리스너 제거 ---
+            turnEngine.events.off('turn-changed', this.onTurnChanged, this);
         });
+    }
+
+    /**
+     * 턴이 변경될 때 호출되는 함수
+     * @param {object} newUnit - 새로운 턴의 유닛
+     */
+    onTurnChanged(newUnit) {
+        // 이전 턴 유닛의 애니메이션 클래스 제거
+        if (this.currentTurnUnitElement) {
+            this.currentTurnUnitElement.classList.remove('is-turn');
+        }
+
+        if (!newUnit) return;
+
+        // 새로운 턴의 유닛 DOM 요소를 찾아서 애니메이션 클래스 추가
+        const unitElement = document.querySelector(`.battle-unit[data-unit-id='${newUnit.uniqueId}']`);
+        if (unitElement) {
+            unitElement.classList.add('is-turn');
+            this.currentTurnUnitElement = unitElement;
+        }
     }
 
     update() {
         battleEngine.update();
+        // --- (추가) 매 프레임 바인딩 매니저 업데이트 ---
+        bindingManager.update();
     }
 }
 

--- a/src/game/utils/BindingManager.js
+++ b/src/game/utils/BindingManager.js
@@ -1,0 +1,87 @@
+/**
+ * 게임 유닛과 DOM UI 요소(이름표, 체력바 등)를 연결하고 관리하는 매니저 (싱글턴)
+ */
+class BindingManager {
+    constructor() {
+        this.bindings = new Map(); // key: unitId, value: { unit, unitElement, uiElements: {} }
+        this.uiContainer = document.getElementById('ui-container');
+    }
+
+    /**
+     * 유닛과 DOM 요소를 바인딩합니다.
+     * @param {object} unit - 유닛 데이터 객체
+     * @param {HTMLElement} unitElement - 유닛의 메인 DOM 요소
+     */
+    bindUnit(unit, unitElement) {
+        if (!unit || !unitElement) return;
+
+        const binding = {
+            unit,
+            unitElement,
+            uiElements: {}
+        };
+        this.bindings.set(unit.uniqueId, binding);
+
+        // 이름표 생성 및 바인딩
+        this.createNameplate(binding);
+    }
+
+    /**
+     * 특정 유닛의 바인딩을 해제합니다.
+     * @param {number} unitId - 해제할 유닛의 ID
+     */
+    unbindUnit(unitId) {
+        const binding = this.bindings.get(unitId);
+        if (binding) {
+            // 연결된 모든 UI 요소를 DOM에서 제거
+            Object.values(binding.uiElements).forEach(ui => ui.remove());
+            this.bindings.delete(unitId);
+        }
+    }
+
+    /**
+     * 바인딩된 유닛의 이름표를 생성하고 관리 목록에 추가합니다.
+     * @param {object} binding - 유닛의 바인딩 정보
+     */
+    createNameplate(binding) {
+        const nameplate = document.createElement('div');
+        nameplate.className = `bound-ui-element ${binding.unit.type === 'ally' ? 'ally' : 'enemy'}`;
+        nameplate.innerText = binding.unit.instanceName || binding.unit.name;
+
+        binding.uiElements.nameplate = nameplate;
+        this.uiContainer.appendChild(nameplate);
+    }
+
+    /**
+     * 매 프레임 호출되어 모든 바인딩된 UI의 위치를 동기화합니다.
+     */
+    update() {
+        const battleGridRect = document.getElementById('battle-grid')?.getBoundingClientRect();
+        if (!battleGridRect) return;
+
+        for (const binding of this.bindings.values()) {
+            const unitRect = binding.unitElement.getBoundingClientRect();
+            const nameplate = binding.uiElements.nameplate;
+
+            if (nameplate) {
+                // 이름표를 유닛의 발밑 중앙에 위치시킵니다.
+                const x = unitRect.left + (unitRect.width / 2);
+                const y = unitRect.bottom;
+
+                // transform을 사용하여 부드럽게 위치를 업데이트합니다.
+                nameplate.style.transform = `translate(-50%, 0) translate(${x}px, ${y}px)`;
+            }
+        }
+    }
+
+    /**
+     * 모든 바인딩을 초기화합니다.
+     */
+    clear() {
+        for (const unitId of this.bindings.keys()) {
+            this.unbindUnit(unitId);
+        }
+    }
+}
+
+export const bindingManager = new BindingManager();

--- a/src/game/utils/TurnEngine.js
+++ b/src/game/utils/TurnEngine.js
@@ -1,7 +1,12 @@
+// --- (수정) Phaser 이벤트 모듈 import ---
+import { Events } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
 class TurnEngine {
     constructor() {
         this.turnQueue = [];
         this.currentIndex = 0;
+        // --- (추가) 이벤트 이미터 생성 ---
+        this.events = new Events.EventEmitter();
     }
 
     init(allies = [], enemies = []) {
@@ -20,6 +25,8 @@ class TurnEngine {
     advance() {
         if (this.turnQueue.length === 0) return;
         this.currentIndex = (this.currentIndex + 1) % this.turnQueue.length;
+        // --- (추가) 턴 변경 이벤트 발생 ---
+        this.events.emit('turn-changed', this.getCurrentUnit());
     }
 }
 


### PR DESCRIPTION
## Summary
- animate active battle unit with idle float animation
- show nameplates using new BindingManager
- control DOM positions through BindingManager in BattleDOMEngine
- update SampleBattleScene to hook turn events and highlight current unit
- emit `turn-changed` event from TurnEngine

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687f39010f5c8327a302960c7ea43d25