### PR TITLE
Implement HP bar and debug managers

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -718,3 +718,21 @@ body {
 .battle-unit-name.enemy {
     background-color: rgba(255, 0, 0, 0.6);
 }
+
+.health-bar-container {
+    position: absolute;
+    width: 60px;
+    height: 8px;
+    background-color: #333;
+    border: 1px solid #000;
+    border-radius: 3px;
+    overflow: hidden;
+    will-change: transform;
+}
+
+.health-bar-fill {
+    width: 100%;
+    height: 100%;
+    background-color: #dc2626;
+    transition: width 0.3s ease-in-out;
+}

--- a/src/game/debug/DebugSpriteCoordinateManager.js
+++ b/src/game/debug/DebugSpriteCoordinateManager.js
@@ -1,0 +1,31 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+import { bindingManager } from '../utils/BindingManager.js';
+import { formationEngine } from '../utils/FormationEngine.js';
+
+class DebugSpriteCoordinateManager {
+    constructor() {
+        this.name = 'DebugSpriteCoords';
+        this.enabled = true;
+        debugLogEngine.register(this);
+    }
+
+    logSpriteCoordinates(unit, turnPhase) {
+        if (!this.enabled || !unit) return;
+
+        const binding = bindingManager.getBinding(unit.uniqueId);
+        const logicalPosition = formationEngine.getPosition(unit.uniqueId);
+
+        if (binding && binding.spriteElement) {
+            const spriteRect = binding.spriteElement.getBoundingClientRect();
+            console.groupCollapsed(`%c[${this.name}]`, `color: #f59e0b; font-weight: bold;`, `Unit ${unit.instanceName} (ID: ${unit.uniqueId}) - ${turnPhase}`);
+            debugLogEngine.log(this.name, `논리적 위치 (Cell Index): ${logicalPosition}`);
+            debugLogEngine.log(this.name, `스프라이트 실제 좌표 (x, y): ${spriteRect.left.toFixed(2)}, ${spriteRect.top.toFixed(2)}`);
+            debugLogEngine.log(this.name, `스프라이트 크기 (w, h): ${spriteRect.width.toFixed(2)}, ${spriteRect.height.toFixed(2)}`);
+            console.groupEnd();
+        } else {
+            debugLogEngine.warn(this.name, `Unit ID ${unit.uniqueId}의 스프라이트 바인딩 정보를 찾을 수 없습니다.`);
+        }
+    }
+}
+
+export const debugSpriteCoordinateManager = new DebugSpriteCoordinateManager();

--- a/src/game/debug/DebugVFXManager.js
+++ b/src/game/debug/DebugVFXManager.js
@@ -1,0 +1,17 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugVFXManager {
+    constructor() {
+        this.name = 'DebugVFX';
+        this.enabled = true;
+        debugLogEngine.register(this);
+    }
+
+    logVFXCoordinates(vfxElement, unitId) {
+        if (!this.enabled || !vfxElement) return;
+        const rect = vfxElement.getBoundingClientRect();
+        console.log(`%c[${this.name}]`, `color: #10b981; font-weight: bold;`, `Unit ID ${unitId} | VFX Pos: (x: ${rect.left.toFixed(2)}, y: ${rect.top.toFixed(2)})`);
+    }
+}
+
+export const debugVFXManager = new DebugVFXManager();

--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -1,4 +1,5 @@
 import { formationEngine } from '../utils/FormationEngine.js';
+import { bindingManager } from '../utils/BindingManager.js';
 
 export class BattleDOMEngine {
     constructor(scene) {
@@ -127,6 +128,7 @@ export class BattleDOMEngine {
             name.innerText = unit.instanceName || unit.name;
             unitDiv.appendChild(name);
             cell.appendChild(unitDiv);
+            bindingManager.bind(unit.uniqueId, { spriteElement: unitDiv });
         });
     }
 
@@ -144,6 +146,7 @@ export class BattleDOMEngine {
             name.innerText = mon.instanceName || mon.name;
             unitDiv.appendChild(name);
             cell.appendChild(unitDiv);
+            bindingManager.bind(mon.uniqueId, { spriteElement: unitDiv });
         });
     }
 
@@ -157,5 +160,6 @@ export class BattleDOMEngine {
             this.container.removeEventListener('mouseup', this._mouseUpHandler);
             this.container.removeEventListener('mouseleave', this._mouseLeaveHandler);
         }
+        bindingManager.clear();
     }
 }

--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -6,11 +6,13 @@ import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
 import { battleEngine } from '../utils/BattleEngine.js';
+import { VfxEngine } from '../utils/VfxEngine.js';
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
         super('CursedForestBattle');
         this.battleDomEngine = null;
+        this.vfxEngine = null;
     }
 
     create() {
@@ -21,12 +23,17 @@ export class CursedForestBattleScene extends Scene {
 
         const domEngine = new DOMEngine(this);
         this.battleDomEngine = new BattleDOMEngine(this, domEngine);
+        this.vfxEngine = new VfxEngine();
         this.battleDomEngine.createStage('assets/images/battle/battle-stage-cursed-forest.png');
 
         const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
         const allMercs = mercenaryEngine.getAllAlliedMercenaries();
         const partyUnits = allMercs.filter(m => partyIds.includes(m.uniqueId));
         this.battleDomEngine.placeAllies(partyUnits);
+        partyUnits.forEach(unit => {
+            this.vfxEngine.createHealthBar(unit, 100);
+            this.vfxEngine.updateHealthBar(unit.uniqueId, 100, 100);
+        });
 
         const monsters = [];
         const zombieBase = getMonsterBase('zombie');
@@ -34,6 +41,10 @@ export class CursedForestBattleScene extends Scene {
             monsters.push(monsterEngine.spawnMonster(zombieBase, 'enemy'));
         }
         this.battleDomEngine.placeMonsters(monsters, 8);
+        monsters.forEach(mon => {
+            this.vfxEngine.createHealthBar(mon, 80);
+            this.vfxEngine.updateHealthBar(mon.uniqueId, 80, 80);
+        });
 
         battleEngine.startBattle(partyUnits, monsters);
 
@@ -45,6 +56,10 @@ export class CursedForestBattleScene extends Scene {
 
             if (this.battleDomEngine) {
                 this.battleDomEngine.destroy();
+            }
+            if (this.vfxEngine) {
+                this.vfxEngine.destroy();
+                this.vfxEngine = null;
             }
             battleEngine.endBattle();
         });

--- a/src/game/utils/BindingManager.js
+++ b/src/game/utils/BindingManager.js
@@ -1,0 +1,27 @@
+class BindingManager {
+    constructor() {
+        this.bindings = new Map();
+    }
+
+    bind(unitId, elements) {
+        if (!this.bindings.has(unitId)) {
+            this.bindings.set(unitId, {});
+        }
+        const existing = this.bindings.get(unitId);
+        Object.assign(existing, elements);
+    }
+
+    getBinding(unitId) {
+        return this.bindings.get(unitId);
+    }
+
+    unbind(unitId) {
+        this.bindings.delete(unitId);
+    }
+
+    clear() {
+        this.bindings.clear();
+    }
+}
+
+export const bindingManager = new BindingManager();

--- a/src/game/utils/TurnEngine.js
+++ b/src/game/utils/TurnEngine.js
@@ -1,3 +1,5 @@
+import { debugSpriteCoordinateManager } from '../debug/DebugSpriteCoordinateManager.js';
+
 class TurnEngine {
     constructor() {
         this.turnQueue = [];
@@ -14,7 +16,11 @@ class TurnEngine {
     }
 
     getCurrentUnit() {
-        return this.turnQueue[this.currentIndex];
+        const unit = this.turnQueue[this.currentIndex];
+        if (unit) {
+            debugSpriteCoordinateManager.logSpriteCoordinates(unit, 'Turn Start');
+        }
+        return unit;
     }
 
     advance() {


### PR DESCRIPTION
## Summary
- manage sprite/VFX associations with `BindingManager`
- extend `VfxEngine` to create and update health bars
- record DOM bindings in `BattleDOMEngine`
- log sprite positions with new debug managers
- display HP bars in `CursedForestBattleScene`
- style the health bars in CSS

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f3ed271a08327bedf4deccc8dc9ad