### PR TITLE
Improve DOM battle sync and add event bus

### DIFF
--- a/src/game/utils/EventBus.js
+++ b/src/game/utils/EventBus.js
@@ -1,0 +1,24 @@
+class EventBus {
+    constructor() {
+        this.events = {};
+    }
+
+    on(event, callback) {
+        if (!this.events[event]) {
+            this.events[event] = [];
+        }
+        this.events[event].push(callback);
+    }
+
+    emit(event, data) {
+        if (this.events[event]) {
+            this.events[event].forEach(cb => cb(data));
+        }
+    }
+
+    off(event) {
+        delete this.events[event];
+    }
+}
+
+export const eventBus = new EventBus();


### PR DESCRIPTION
## Summary
- update `BattleDOMEngine` so sprites are reused when moving units
- publish HP changes through a new event bus
- listen for HP updates in `CursedForestBattleScene`
- connect battle engine events to UI via the bus

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687f41b3e3588327b00f98d17c143db9