### PR TITLE
Fix position for units and health bars in Cursed Forest

### DIFF
--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -136,15 +136,28 @@ export class BattleDOMEngine {
 
     placeAllies(units) {
         if (!this.grid) return;
+
+        const available = this.gridCells.filter(c => !c.hasChildNodes() && parseInt(c.dataset.col) < 8);
+
         units.forEach(unit => {
             if (!this.unitSpriteMap.has(unit.uniqueId)) {
                 this.createUnitSprite(unit);
             }
+
             const sprite = this.unitSpriteMap.get(unit.uniqueId);
-            const index = formationEngine.getPosition(unit.uniqueId);
-            const cell = this.gridCells[index];
+            let index = formationEngine.getPosition(unit.uniqueId);
+            let cell = this.gridCells[index];
+
+            if (!cell || cell.hasChildNodes() || parseInt(cell.dataset.col) >= 8) {
+                cell = available.shift();
+                if (cell) {
+                    formationEngine.setPosition(unit.uniqueId, parseInt(cell.dataset.index));
+                }
+            }
+
             if (cell) {
                 cell.appendChild(sprite);
+                sprite.dataset.cellIndex = cell.dataset.index;
             }
         });
     }

--- a/src/game/utils/VfxEngine.js
+++ b/src/game/utils/VfxEngine.js
@@ -73,10 +73,16 @@ export class VfxEngine {
 
         const healthBarContainer = document.createElement('div');
         healthBarContainer.className = 'health-bar-container';
+        healthBarContainer.style.position = 'absolute';
+        healthBarContainer.style.left = '0';
+        healthBarContainer.style.top = '0';
 
         const fill = document.createElement('div');
         fill.className = 'health-bar-fill';
         fill.style.width = '100%';
+        fill.style.position = 'absolute';
+        fill.style.left = '0';
+        fill.style.top = '0';
 
         healthBarContainer.appendChild(fill);
         this.uiContainer.appendChild(healthBarContainer);


### PR DESCRIPTION
## Summary
- handle missing formation slot when spawning allies
- ensure health bar container and gauge are absolutely positioned

## Testing
- `python3 -m http.server 8000 & sleep 1 && curl -s http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687f46ed38a883278fdbdaf1df4e23c3